### PR TITLE
UI monitor: auto-close recovered issue; adjust data-refresh schedule and backfill behavior

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -32,8 +32,8 @@ on:
   schedule:
     # 09:10 / 12:10 / 15:10 / 18:10 JST: keep same-day partial snapshots
     - cron: "10 0,3,6,9 * * *"
-    # 16:10 JST (07:10 UTC): refresh recent fixed datasets, retrying yesterday if publication was delayed
-    - cron: "10 7 * * *"
+    # 11:10 / 16:10 JST (02:10 / 07:10 UTC): refresh recent fixed datasets, retrying yesterday if publication was delayed
+    - cron: "10 2,7 * * *"
 
 permissions:
   contents: write
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            if [ "${{ github.event.schedule }}" = "10 7 * * *" ]; then
+            if [ "${{ github.event.schedule }}" = "10 2,7 * * *" ]; then
               FROM="$(date -u -d '2 days ago' '+%Y-%m-%d')"
               TO="$(date -u -d '1 day ago' '+%Y-%m-%d')"
               echo "Scheduled fixed-data refresh for recent dates: ${FROM}..${TO}"

--- a/.github/workflows/ui-monitor.yml
+++ b/.github/workflows/ui-monitor.yml
@@ -92,3 +92,43 @@ jobs:
                 body,
               });
             }
+
+      - name: Close failure issue when recovered
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "[UI Monitor] GitHub Pages health check failed";
+            const recoveryRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            const existing = issues.find((issue) => issue.title === title);
+            if (!existing) {
+              core.info("No open UI monitor failure issue found.");
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: existing.number,
+              body: [
+                "UI Monitor が再実行で成功したため、この障害Issueをクローズします。",
+                "",
+                `- Recovery run: ${recoveryRunUrl}`,
+                `- UTC: ${new Date().toISOString()}`,
+              ].join("\n"),
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: existing.number,
+              state: "closed",
+            });

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ PR / push 時に以下を実行:
 - ワークフロー: [data-refresh.yml](.github/workflows/data-refresh.yml)
 - 定時実行:
   1. **09:10 / 12:10 / 15:10 / 18:10 JST** に `mode=now` を実行して、当日分の途中経過を保存
-  2. **16:10 JST**（= **07:10 UTC**）に `mode=daily` を実行して、前日分の確定版を保存
+  2. **11:10 / 16:10 JST**（= **02:10 / 07:10 UTC**）に固定データの再取得を実行し、前日分の公開遅延をリトライ
 - 処理内容:
-  1. schedule時は `mode=now` または `mode=daily` を時刻ごとに切り替えて実行
+  1. schedule時は `mode=now` または `mode=backfill` を時刻ごとに切り替えて実行
   2. 発電実績 + 地内基幹送電線 + 地域間連系線のCSVを取得して正規化
   3. `data/normalized` に差分があれば自動コミット＆push
   4. `main` へのpushをトリガーに Pages デプロイが走る


### PR DESCRIPTION
### Motivation
- Reduce missed updates by adding an earlier fixed-data refresh time and allow retrying recent publication delays. 
- Ensure the UI Monitor workflow not only files an issue on failure but also closes it automatically when the check recovers. 
- Keep documentation in sync with workflow behavior and mode naming. 

### Description
- Updated `data-refresh.yml` schedule cron from `10 7 * * *` to `10 2,7 * * *` and adjusted the schedule-time comment to reflect `11:10 / 16:10 JST (02:10 / 07:10 UTC)`. 
- Aligned the scheduled-run conditional in `data-refresh.yml` to check for `10 2,7 * * *` and preserved the backfill invocation using `npm run ingest -- --mode=backfill` for the fixed-data retry window. 
- Added a new step to `ui-monitor.yml` that runs `actions/github-script@v7` on success to find the existing "[UI Monitor] GitHub Pages health check failed" issue, post a recovery comment (including the recovery run URL and UTC timestamp), and close the issue. 
- Updated `README.md` to reflect the new schedule times, changed descriptive wording to reference `backfill` where appropriate, and document the dual fixed-data refresh times. 

### Testing
- No automated tests were executed as part of this change; existing CI checks (`npm run lint`, `npm run build`, `npm run test:ui`) will run on the repository workflow runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b255368f008321b5ea2900bd26514b)