### PR TITLE
feat: UI/UX improvements and network visualization enhancements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,13 @@
   --foreground: #182230;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0f172a;
+    --foreground: #e2e8f0;
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -54,6 +54,7 @@ import {
   clampPointToMapBounds,
   isNetworkPowerPlantSource,
   buildJapanGuideGraphics,
+  flowMagnitudeColor,
 } from "@/lib/geo";
 import {
   type BarListItem,
@@ -68,7 +69,9 @@ import {
   SupplyDemandMeter,
   NetFlowMeter,
   CompositionLegendList,
+  LoadingOverlay,
 } from "@/components/ui/dashboard-ui";
+import { ChartErrorBoundary } from "@/components/ui/error-boundary";
 
 const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
 
@@ -979,6 +982,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
         }
         return {
           coords: buildCurvedLineCoords(from, to, line.lineStyle.curveness),
+          absAvgMw: line.absAvgMw,
           lineStyle: {
             color: "rgba(125,211,252,0.42)",
             width: Math.max(1.4, line.lineStyle.width * 0.72),
@@ -987,12 +991,14 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
         };
       })
       .filter((item) => item !== null);
+    const maxAnimatedFlowMw = Math.max(...animatedFlowLines.map((line) => line.absAvgMw), 1);
     const majorFlowAnimationPaths: NetworkAnimationPath[] = animatedFlowLines.map((line, index) => ({
       id: `major-flow-${index}`,
       d: buildSvgQuadraticPath(line.coords),
       strokeWidth: Math.max(2.1, line.lineStyle.width + 0.35),
       durationSeconds: roundTo(1.7 + (index % 4) * 0.18, 2),
       delaySeconds: roundTo((index % 5) * 0.12, 2),
+      magnitude: clamp(line.absAvgMw / maxAnimatedFlowMw, 0, 1),
     }));
     const maxAbsIntertieFacility = Math.max(...Array.from(intertieFacilityMap.values()).map((item) => item.absMw), 1);
     const intertieFacilityLines = Array.from(intertieFacilityMap.values())
@@ -1706,28 +1712,35 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
   }, [data.flows.intertieSeries, data.meta.slotLabels.flow, selectedArea]);
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_#f4f1de_0%,_#f6f8fb_38%,_#e9f5f2_100%)] text-slate-800">
-      <div className="mx-auto flex w-full max-w-[1320px] flex-col gap-5 px-4 py-6 md:px-8">
-        <header className="rounded-3xl border border-white/70 bg-white/80 px-5 py-5 shadow-sm backdrop-blur">
+    <div className="relative min-h-screen bg-[radial-gradient(circle_at_top_left,_#f4f1de_0%,_#f6f8fb_38%,_#e9f5f2_100%)] text-slate-800 dark:bg-[radial-gradient(circle_at_top_left,_#1a1a2e_0%,_#16213e_38%,_#0f3460_100%)] dark:text-slate-200">
+      <a
+        href="#dashboard-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-teal-600 focus:px-4 focus:py-2 focus:text-white focus:shadow-lg"
+      >
+        コンテンツへスキップ
+      </a>
+      <LoadingOverlay visible={isDateLoading} />
+      <div id="dashboard-content" className="mx-auto flex w-full max-w-[1320px] flex-col gap-5 px-4 py-6 md:px-8">
+        <header className="rounded-3xl border border-white/70 bg-white/80 px-5 py-5 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800/80">
           <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div>
-              <p className="text-xs tracking-[0.18em] text-teal-700">OCCTO GRID OBSERVATORY</p>
+              <p className="text-xs tracking-[0.18em] text-teal-700 dark:text-teal-400">OCCTO GRID OBSERVATORY</p>
               <h1 className="text-2xl font-semibold leading-tight md:text-3xl">
                 送電潮流 × ユニット発電実績 ダッシュボード
               </h1>
-              <p className="text-sm text-slate-600">
+              <p className="text-sm text-slate-600 dark:text-slate-400">
                 対象日: {data.meta.targetDate} / 最終取り込み: {fetchedAtLabel}
               </p>
             </div>
             <div className="flex flex-col items-start gap-2 md:items-end">
               <div className="flex flex-wrap items-center gap-2">
-                <label htmlFor="dashboard-date" className="text-sm font-medium text-slate-600">
+                <label htmlFor="dashboard-date" className="text-sm font-medium text-slate-600 dark:text-slate-400">
                   対象日
                 </label>
                 <input
                   id="dashboard-date"
                   type="date"
-                  className="rounded-xl border border-teal-200 bg-white px-3 py-2 text-sm focus:border-teal-500 focus:outline-none"
+                  className="rounded-xl border border-teal-200 bg-white px-3 py-2 text-sm focus:border-teal-500 focus:outline-none dark:border-teal-800 dark:bg-slate-800 dark:text-slate-200"
                   value={toInputDateValue(selectedDate)}
                   min={toInputDateValue(earliestAvailableDate)}
                   onChange={(event) => {
@@ -1745,18 +1758,23 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
                   }}
                   disabled={isDateLoading}
                 />
-                {isDateLoading ? <span className="text-xs text-teal-700">読み込み中...</span> : null}
+                {isDateLoading ? (
+                  <span className="inline-flex items-center gap-1.5 text-xs text-teal-700 dark:text-teal-400">
+                    <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-teal-200 border-t-teal-600" />
+                    読み込み中...
+                  </span>
+                ) : null}
               </div>
-              <p className="text-xs text-slate-500">
+              <p className="text-xs text-slate-500 dark:text-slate-400">
                 公開データ範囲: {earliestAvailableDate} から {latestAvailableDate}
               </p>
               <div className="flex items-center gap-2">
-                <label htmlFor="area" className="text-sm font-medium text-slate-600">
+                <label htmlFor="area" className="text-sm font-medium text-slate-600 dark:text-slate-400">
                   エリア
                 </label>
                 <select
                   id="area"
-                  className="rounded-xl border border-teal-200 bg-white px-3 py-2 text-sm focus:border-teal-500 focus:outline-none"
+                  className="rounded-xl border border-teal-200 bg-white px-3 py-2 text-sm focus:border-teal-500 focus:outline-none dark:border-teal-800 dark:bg-slate-800 dark:text-slate-200"
                   value={selectedArea}
                   onChange={(event) => setSelectedArea(event.target.value)}
                 >
@@ -1767,26 +1785,26 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
                   ))}
                 </select>
               </div>
-              {dateError ? <p className="text-xs text-rose-700">{dateError}</p> : null}
+              {dateError ? <p className="text-xs text-rose-700 dark:text-rose-400">{dateError}</p> : null}
             </div>
           </div>
         </header>
-        <section className="rounded-3xl border border-white/70 bg-white/85 p-4 shadow-sm backdrop-blur">
+        <section className="rounded-3xl border border-white/70 bg-white/85 p-4 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800/85">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div>
-              <h2 className="text-base font-semibold text-slate-800">表示するパネル</h2>
+              <h2 className="text-base font-semibold text-slate-800 dark:text-slate-200">表示するパネル</h2>
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <button
                 type="button"
-                className="rounded-full border border-slate-300 px-3 py-1 text-sm text-slate-700 transition hover:border-teal-400 hover:text-teal-700"
+                className="rounded-full border border-slate-300 px-3 py-1 text-sm text-slate-700 transition hover:border-teal-400 hover:text-teal-700 dark:border-slate-600 dark:text-slate-300 dark:hover:border-teal-500 dark:hover:text-teal-400"
                 onClick={() => setVisibleSectionIds(DASHBOARD_SECTION_OPTIONS.map((item) => item.id))}
               >
                 すべて表示
               </button>
               <button
                 type="button"
-                className="rounded-full border border-slate-300 px-3 py-1 text-sm text-slate-700 transition hover:border-teal-400 hover:text-teal-700"
+                className="rounded-full border border-slate-300 px-3 py-1 text-sm text-slate-700 transition hover:border-teal-400 hover:text-teal-700 dark:border-slate-600 dark:text-slate-300 dark:hover:border-teal-500 dark:hover:text-teal-400"
                 onClick={() => setVisibleSectionIds(["summary", "areaCards", "composition", "network"])}
               >
                 俯瞰モード
@@ -1800,10 +1818,12 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
                 <button
                   key={item.id}
                   type="button"
+                  role="switch"
+                  aria-checked={active}
                   className={`rounded-full border px-3 py-1.5 text-sm transition ${
                     active
                       ? "border-teal-500 bg-teal-600 text-white shadow-sm"
-                      : "border-slate-300 bg-white text-slate-700 hover:border-teal-400 hover:text-teal-700"
+                      : "border-slate-300 bg-white text-slate-700 hover:border-teal-400 hover:text-teal-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:border-teal-500 dark:hover:text-teal-400"
                   }`}
                   onClick={() =>
                     setVisibleSectionIds((current) => {
@@ -2109,6 +2129,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
         ) : null}
 
         {showGenerationTrend || showSourceComposition ? (
+          <ChartErrorBoundary sectionName="発電トレンド・構成">
           <section className="grid grid-cols-1 gap-4 lg:grid-cols-12">
             {showGenerationTrend ? (
               <Panel
@@ -2133,7 +2154,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
                     ))}
                   </select>
                 </div>
-                <div data-testid="generation-trend-chart">
+                <div data-testid="generation-trend-chart" role="img" aria-label="発電方式別30分推移チャート">
                   <ReactECharts option={generationLineOption} style={{ height: 360 }} />
                 </div>
               </Panel>
@@ -2166,7 +2187,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
                     useInlineDonutLegend ? "grid lg:grid-cols-[minmax(0,300px)_minmax(0,1fr)]" : ""
                   }`}
                 >
-                  <div data-testid="source-composition-chart" className="mx-auto w-full max-w-[300px]">
+                  <div data-testid="source-composition-chart" role="img" aria-label="発電方式構成比チャート" className="mx-auto w-full max-w-[300px]">
                     <ReactECharts option={sourceDonutOption} style={{ height: 300 }} />
                   </div>
                   <CompositionLegendList
@@ -2177,43 +2198,49 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
               </Panel>
             ) : null}
           </section>
+          </ChartErrorBoundary>
         ) : null}
 
         {visibleSectionSet.has("reserve") ? (
+          <ChartErrorBoundary sectionName="需要・予備率">
           <section className="grid grid-cols-1 gap-4 lg:grid-cols-12">
             <Panel title="エリア予備率（30分推移）" className="lg:col-span-7" testId="reserve-trend-panel">
               <div className="mb-2 text-xs text-slate-600">
                 公式値ベース。{selectedArea === "全エリア" ? "全エリア" : `${selectedArea}`} / {data.meta.targetDate}
               </div>
-              <div data-testid="reserve-trend-chart">
+              <div data-testid="reserve-trend-chart" role="img" aria-label="エリア予備率推移チャート">
                 <ReactECharts option={reserveTrendOption} style={{ height: 320 }} />
               </div>
             </Panel>
             <Panel title="エリア需要・予備力（表示時刻）" className="lg:col-span-5" testId="reserve-current-panel">
               <div className="mb-2 text-xs text-slate-600">表示日時: {selectedFlowDateTimeLabel}</div>
-              <div data-testid="reserve-current-chart">
+              <div data-testid="reserve-current-chart" role="img" aria-label="エリア需要・予備力チャート">
                 <ReactECharts option={reserveCurrentOption} style={{ height: 320 }} />
               </div>
             </Panel>
           </section>
+          </ChartErrorBoundary>
         ) : null}
 
         {visibleSectionSet.has("totals") ? (
+          <ChartErrorBoundary sectionName="発電・連系概要">
           <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <Panel title="エリア別 日量発電" testId="area-total-generation-panel">
-              <div data-testid="area-total-generation-chart">
+              <div data-testid="area-total-generation-chart" role="img" aria-label="エリア別日量発電チャート">
                 <ReactECharts option={areaTotalsOption} style={{ height: 320 }} />
               </div>
             </Panel>
             <Panel title="連系線潮流トレンド（時系列）" testId="intertie-trend-panel">
-              <div data-testid="intertie-trend-chart">
+              <div data-testid="intertie-trend-chart" role="img" aria-label="連系線潮流トレンドチャート">
                 <ReactECharts option={intertieTrendOption} style={{ height: 320 }} />
               </div>
             </Panel>
           </section>
+          </ChartErrorBoundary>
         ) : null}
 
         {visibleSectionSet.has("network") ? (
+          <ChartErrorBoundary sectionName="ネットワーク">
           <section className="grid grid-cols-1 gap-4 lg:grid-cols-3">
             <Panel title="エリアネットワーク潮流（地域内送電線）" className="lg:col-span-2" testId="network-flow-panel">
               <div className="mb-3 rounded-xl border border-slate-200 bg-white/80 px-3 py-2">
@@ -2245,7 +2272,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
                   各エリアの主要潮流を最大10本ずつ、水色の破線アニメーションで表示しています。
                 </p>
               </div>
-              <div data-testid="network-flow-chart" className="relative" ref={networkFlowChartHostRef}>
+              <div data-testid="network-flow-chart" role="img" aria-label="ネットワーク潮流グラフ" className="relative" ref={networkFlowChartHostRef}>
                 <ReactECharts
                   option={flowNetworkOption}
                   style={{ height: 620 }}
@@ -2268,30 +2295,35 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
                       transform={formatSvgMatrixTransform(networkOverlayViewport.roam)}
                     >
                       <g transform={formatSvgMatrixTransform(networkOverlayViewport.raw)}>
-                        {majorFlowAnimationPaths.map((path) => (
-                          <g key={path.id}>
-                            <path
-                              d={path.d}
-                              fill="none"
-                              stroke="rgba(56,189,248,0.38)"
-                              strokeWidth={path.strokeWidth + 1.2}
-                              strokeLinecap="round"
-                            />
-                            <path
-                              d={path.d}
-                              fill="none"
-                              stroke="rgba(255,255,255,0.96)"
-                              strokeWidth={path.strokeWidth}
-                              strokeLinecap="round"
-                              strokeDasharray="22 20"
-                              style={{
-                                animation: `network-flow-dash ${path.durationSeconds}s linear infinite`,
-                                animationDelay: `-${path.delaySeconds}s`,
-                                filter: "drop-shadow(0 0 2px rgba(56,189,248,0.95))",
-                              }}
-                            />
-                          </g>
-                        ))}
+                        {majorFlowAnimationPaths.map((path) => {
+                          const glowColor = flowMagnitudeColor(path.magnitude, 0.38);
+                          const dashColor = flowMagnitudeColor(path.magnitude, 0.92);
+                          const shadowColor = flowMagnitudeColor(path.magnitude, 0.95);
+                          return (
+                            <g key={path.id}>
+                              <path
+                                d={path.d}
+                                fill="none"
+                                stroke={glowColor}
+                                strokeWidth={path.strokeWidth + 1.2}
+                                strokeLinecap="round"
+                              />
+                              <path
+                                d={path.d}
+                                fill="none"
+                                stroke={dashColor}
+                                strokeWidth={path.strokeWidth}
+                                strokeLinecap="round"
+                                strokeDasharray="22 20"
+                                style={{
+                                  animation: `network-flow-dash ${path.durationSeconds}s linear infinite`,
+                                  animationDelay: `-${path.delaySeconds}s`,
+                                  filter: `drop-shadow(0 0 2px ${shadowColor})`,
+                                }}
+                              />
+                            </g>
+                          );
+                        })}
                       </g>
                     </g>
                   </svg>
@@ -2300,24 +2332,28 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
             </Panel>
             <Panel title="エリア間連系潮流（実績）" testId="inter-area-flow-panel">
               <div className="mb-2 text-xs text-slate-600">表示日時: {selectedFlowDateTimeLabel}</div>
-              <div data-testid="inter-area-flow-chart">
+              <div data-testid="inter-area-flow-chart" role="img" aria-label="エリア間連系潮流チャート">
                 <ReactECharts option={interAreaFlowOption} style={{ height: isMobileViewport ? 520 : 594 }} />
               </div>
             </Panel>
           </section>
+          </ChartErrorBoundary>
         ) : null}
 
         {visibleSectionSet.has("diagnostics") ? (
+          <ChartErrorBoundary sectionName="潮流ヒートマップ">
           <section className="grid grid-cols-1 gap-4">
             <Panel title="主要線路の潮流ヒートマップ">
               <p className="mb-2 text-xs text-slate-500">主要線路の時間帯別の潮流強度を俯瞰します。</p>
               <ReactECharts option={flowHeatmapOption} style={{ height: 420 }} />
             </Panel>
           </section>
+          </ChartErrorBoundary>
         ) : null}
 
         {visibleSectionSet.has("rankings") ? (
-          <section className="rounded-3xl border border-white/70 bg-white/90 p-4 shadow-sm">
+          <ChartErrorBoundary sectionName="ランキング">
+          <section className="rounded-3xl border border-white/70 bg-white/90 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800/90">
             <h2 className="mb-3 text-lg font-semibold">高発電ユニット上位</h2>
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm">
@@ -2376,6 +2412,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
               </table>
             </div>
           </section>
+          </ChartErrorBoundary>
         ) : null}
       </div>
     </div>

--- a/src/components/ui/dashboard-ui.tsx
+++ b/src/components/ui/dashboard-ui.tsx
@@ -28,9 +28,9 @@ export function Panel({
   return (
     <section
       data-testid={testId}
-      className={`rounded-3xl border border-white/70 bg-white/90 p-4 shadow-sm ${className ?? ""}`}
+      className={`rounded-3xl border border-white/70 bg-white/90 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800/90 ${className ?? ""}`}
     >
-      <h2 className="mb-2 text-base font-semibold text-slate-800">{title}</h2>
+      <h2 className="mb-2 text-base font-semibold text-slate-800 dark:text-slate-200">{title}</h2>
       {children}
     </section>
   );
@@ -50,15 +50,15 @@ export function SummaryCard({
   children: ReactNode;
 }) {
   return (
-    <article className="rounded-3xl border border-white/70 bg-white/92 p-4 shadow-sm">
+    <article className="rounded-3xl border border-white/70 bg-white/92 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800/92">
       <div className="flex items-start justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
             <span className="inline-flex h-2.5 w-2.5 rounded-full" style={{ backgroundColor: accentColor }} />
-            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">{title}</p>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">{title}</p>
           </div>
-          <p className="mt-2 text-xl font-semibold leading-tight text-slate-900">{value}</p>
-          <p className="mt-2 text-sm text-slate-600">{detail}</p>
+          <p className="mt-2 text-xl font-semibold leading-tight text-slate-900 dark:text-slate-100">{value}</p>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{detail}</p>
         </div>
       </div>
       <div className="mt-4">{children}</div>
@@ -78,10 +78,10 @@ export function CompactStatCard({
   className?: string;
 }) {
   return (
-    <div className={`rounded-2xl border border-slate-200 bg-white/80 px-4 py-3 ${className ?? ""}`}>
-      <p className="text-xs tracking-[0.16em] text-slate-500">{label}</p>
-      <p className="mt-1 text-base font-semibold text-slate-900">{value}</p>
-      <p className="mt-1 text-sm text-slate-600">{detail}</p>
+    <div className={`rounded-2xl border border-slate-200 bg-white/80 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/80 ${className ?? ""}`}>
+      <p className="text-xs tracking-[0.16em] text-slate-500 dark:text-slate-400">{label}</p>
+      <p className="mt-1 text-base font-semibold text-slate-900 dark:text-slate-100">{value}</p>
+      <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{detail}</p>
     </div>
   );
 }
@@ -96,10 +96,10 @@ export function DataChip({
   color: string;
 }) {
   return (
-    <div className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700">
+    <div className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300">
       <span className="mr-2 inline-flex h-2 w-2 rounded-full align-middle" style={{ backgroundColor: color }} />
       <span>{label}</span>
-      <span className="ml-2 font-medium text-slate-900">{value}</span>
+      <span className="ml-2 font-medium text-slate-900 dark:text-slate-100">{value}</span>
     </div>
   );
 }
@@ -112,7 +112,7 @@ export function SegmentedBar({
   className?: string;
 }) {
   return (
-    <div className={`flex h-3 overflow-hidden rounded-full bg-slate-100 ${className ?? ""}`}>
+    <div className={`flex h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700 ${className ?? ""}`}>
       {segments.map((segment) => (
         <div
           key={`${segment.label}-${segment.color}`}
@@ -138,10 +138,10 @@ export function MiniBarList({
         <div key={`${item.label}-${item.valueLabel}`}>
           <div className="mb-1 flex items-center justify-between gap-3 text-sm">
             <div className="min-w-0">
-              <p className="truncate text-slate-800">{item.label}</p>
-              {item.note ? <p className="truncate text-xs text-slate-500">{item.note}</p> : null}
+              <p className="truncate text-slate-800 dark:text-slate-200">{item.label}</p>
+              {item.note ? <p className="truncate text-xs text-slate-500 dark:text-slate-400">{item.note}</p> : null}
             </div>
-            <p className="shrink-0 font-medium text-slate-900">{item.valueLabel}</p>
+            <p className="shrink-0 font-medium text-slate-900 dark:text-slate-100">{item.valueLabel}</p>
           </div>
           <ValueProgressBar value={item.percent} max={100} color={item.color} />
         </div>
@@ -153,10 +153,10 @@ export function MiniBarList({
 export function ReserveRateBadge({ reserveRate }: { reserveRate: number }) {
   const toneClass =
     reserveRate < 8
-      ? "border-rose-200 bg-rose-50 text-rose-700"
+      ? "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-400"
       : reserveRate < 12
-        ? "border-amber-200 bg-amber-50 text-amber-700"
-        : "border-emerald-200 bg-emerald-50 text-emerald-700";
+        ? "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-400"
+        : "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-400";
   return (
     <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${toneClass}`}>
       予備率 {decimalFmt.format(reserveRate)}%
@@ -175,7 +175,7 @@ export function ValueProgressBar({
 }) {
   const percent = max <= 0 ? 0 : clamp((value / max) * 100, 0, 100);
   return (
-    <div className="h-2.5 overflow-hidden rounded-full bg-slate-100">
+    <div className="h-2.5 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
       <div className="h-full rounded-full" style={{ width: `${percent}%`, backgroundColor: color }} />
     </div>
   );
@@ -196,14 +196,14 @@ export function SupplyDemandMeter({
   const reservePercent = supplyMw > 0 ? clamp((reserveMw / supplyMw) * 100, 0, 100) : 0;
   return (
     <div>
-      <div className="relative h-4 overflow-hidden rounded-full bg-slate-100">
+      <div className="relative h-4 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
         <div className="absolute inset-y-0 left-0 rounded-full" style={{ width: `${demandPercent}%`, backgroundColor: color }} />
         <div
-          className="absolute inset-y-0 right-0 bg-emerald-300/80"
+          className="absolute inset-y-0 right-0 bg-emerald-300/80 dark:bg-emerald-500/60"
           style={{ width: `${reservePercent}%` }}
         />
       </div>
-      <div className="mt-2 flex items-center justify-between text-[11px] text-slate-500">
+      <div className="mt-2 flex items-center justify-between text-[11px] text-slate-500 dark:text-slate-400">
         <span>需要</span>
         <span>供給力</span>
         <span>予備力</span>
@@ -235,8 +235,8 @@ export function NetFlowMeter({
   const negativePercent = valueMw < 0 ? clamp((Math.abs(valueMw) / maxAbsMw) * 50, 0, 50) : 0;
   return (
     <div>
-      <div className="relative h-3 overflow-hidden rounded-full bg-slate-100">
-        <div className="absolute inset-y-0 left-1/2 w-px bg-slate-300" />
+      <div className="relative h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
+        <div className="absolute inset-y-0 left-1/2 w-px bg-slate-300 dark:bg-slate-500" />
         {positivePercent > 0 ? (
           <div
             className="absolute inset-y-0 left-1/2 rounded-r-full"
@@ -250,7 +250,7 @@ export function NetFlowMeter({
           />
         ) : null}
       </div>
-      <div className="mt-2 flex items-center justify-between text-[11px] text-slate-500">
+      <div className="mt-2 flex items-center justify-between text-[11px] text-slate-500 dark:text-slate-400">
         <span>送電</span>
         <span>受電</span>
       </div>
@@ -270,7 +270,7 @@ export function CompositionLegendList({
       {items.map((item) => (
         <div
           key={item.name}
-          className="rounded-xl border border-slate-200 bg-slate-50/80 px-3 py-2"
+          className="rounded-xl border border-slate-200 bg-slate-50/80 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/60"
         >
           <div className="flex items-center gap-2">
             <span
@@ -278,14 +278,34 @@ export function CompositionLegendList({
               style={{ backgroundColor: item.color }}
               aria-hidden="true"
             />
-            <p className="min-w-0 truncate text-sm font-medium text-slate-800">{item.name}</p>
+            <p className="min-w-0 truncate text-sm font-medium text-slate-800 dark:text-slate-200">{item.name}</p>
           </div>
           <div className="mt-1 flex items-end justify-between gap-3 pl-5">
-            <p className="text-xs text-slate-500">{formatCompactEnergy(item.totalKwh)}</p>
-            <p className="shrink-0 text-base font-semibold text-slate-900">{decimalFmt.format(item.percent)}%</p>
+            <p className="text-xs text-slate-500 dark:text-slate-400">{formatCompactEnergy(item.totalKwh)}</p>
+            <p className="shrink-0 text-base font-semibold text-slate-900 dark:text-slate-100">{decimalFmt.format(item.percent)}%</p>
           </div>
         </div>
       ))}
+    </div>
+  );
+}
+
+export function LoadingOverlay({ visible }: { visible: boolean }) {
+  if (!visible) return null;
+  return (
+    <div className="pointer-events-auto absolute inset-0 z-20 flex items-center justify-center rounded-3xl bg-white/60 backdrop-blur-sm dark:bg-slate-900/60">
+      <div className="flex flex-col items-center gap-3">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-teal-200 border-t-teal-600" />
+        <p className="text-sm font-medium text-teal-700 dark:text-teal-400">データ読み込み中...</p>
+      </div>
+    </div>
+  );
+}
+
+export function ChartSkeleton({ height = 320 }: { height?: number }) {
+  return (
+    <div className="animate-pulse" style={{ height }}>
+      <div className="h-full rounded-2xl bg-slate-200/60 dark:bg-slate-700/40" />
     </div>
   );
 }

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type Props = {
+  fallback?: ReactNode;
+  sectionName?: string;
+  children: ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+  error: Error | null;
+};
+
+export class ChartErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(`[ChartErrorBoundary] ${this.props.sectionName ?? "unknown"}:`, error, info.componentStack);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+      return (
+        <div className="flex min-h-[200px] items-center justify-center rounded-2xl border border-rose-200 bg-rose-50/60 p-6 dark:border-rose-800 dark:bg-rose-950/30">
+          <div className="text-center">
+            <p className="text-sm font-medium text-rose-700 dark:text-rose-400">
+              {this.props.sectionName ? `${this.props.sectionName}の` : ""}描画中にエラーが発生しました
+            </p>
+            <p className="mt-1 text-xs text-rose-600/70 dark:text-rose-500/70">
+              {this.state.error?.message ?? "不明なエラー"}
+            </p>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/lib/geo.test.ts
+++ b/src/lib/geo.test.ts
@@ -23,6 +23,8 @@ import {
   DEFAULT_NETWORK_OVERLAY_VIEWPORT,
   AREA_ANCHORS,
   AREA_LAYOUT_BOUNDS,
+  flowMagnitudeColor,
+  buildJapanGuideGraphics,
 } from "./geo";
 
 // ---------- parseDirection ----------
@@ -370,6 +372,50 @@ describe("module-level computed constants", () => {
       expect(anchor.x).toBeLessThanOrEqual(bounds.xMax);
       expect(anchor.y).toBeGreaterThanOrEqual(bounds.yMin);
       expect(anchor.y).toBeLessThanOrEqual(bounds.yMax);
+    }
+  });
+});
+
+// ---------- flowMagnitudeColor ----------
+describe("flowMagnitudeColor", () => {
+  test("returns rgba string", () => {
+    const color = flowMagnitudeColor(0.5);
+    expect(color).toMatch(/^rgba\(\d+,\d+,\d+,[\d.]+\)$/);
+  });
+  test("low magnitude produces blue-ish color", () => {
+    const color = flowMagnitudeColor(0);
+    const match = color.match(/rgba\((\d+),(\d+),(\d+)/);
+    expect(match).not.toBeNull();
+    const [, r, , b] = match!;
+    expect(Number(b)).toBeGreaterThan(Number(r));
+  });
+  test("high magnitude produces red-ish color", () => {
+    const color = flowMagnitudeColor(1);
+    const match = color.match(/rgba\((\d+),(\d+),(\d+)/);
+    expect(match).not.toBeNull();
+    const [, r, , b] = match!;
+    expect(Number(r)).toBeGreaterThan(Number(b));
+  });
+  test("clamps out-of-range values", () => {
+    expect(flowMagnitudeColor(-0.5)).toBe(flowMagnitudeColor(0));
+    expect(flowMagnitudeColor(1.5)).toBe(flowMagnitudeColor(1));
+  });
+  test("custom alpha", () => {
+    const color = flowMagnitudeColor(0.5, 0.5);
+    expect(color).toContain(",0.5)");
+  });
+});
+
+// ---------- buildJapanGuideGraphics ----------
+describe("buildJapanGuideGraphics", () => {
+  test("returns array of polygon graphic elements", () => {
+    const graphics = buildJapanGuideGraphics();
+    expect(graphics.length).toBeGreaterThanOrEqual(4);
+    for (const graphic of graphics) {
+      expect(graphic.type).toBe("polygon");
+      expect(graphic.silent).toBe(true);
+      expect(graphic.shape).toBeDefined();
+      expect((graphic.shape as { points: unknown[] }).points.length).toBeGreaterThan(3);
     }
   });
 });

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -48,7 +48,41 @@ export type NetworkAnimationPath = {
   strokeWidth: number;
   durationSeconds: number;
   delaySeconds: number;
+  /** Normalized 0-1 magnitude for color mapping (0=low flow, 1=high flow) */
+  magnitude: number;
 };
+
+/**
+ * Map a 0-1 magnitude to a color gradient from blue (low) to red (high).
+ * Returns an rgba string suitable for SVG stroke.
+ */
+export function flowMagnitudeColor(magnitude: number, alpha = 0.85): string {
+  const t = clamp(magnitude, 0, 1);
+  // Blue (low) → Cyan → Yellow → Orange → Red (high)
+  let r: number, g: number, b: number;
+  if (t < 0.25) {
+    const s = t / 0.25;
+    r = 30;
+    g = Math.round(80 + s * 140);
+    b = Math.round(220 - s * 30);
+  } else if (t < 0.5) {
+    const s = (t - 0.25) / 0.25;
+    r = Math.round(30 + s * 200);
+    g = Math.round(220 - s * 20);
+    b = Math.round(190 - s * 140);
+  } else if (t < 0.75) {
+    const s = (t - 0.5) / 0.25;
+    r = Math.round(230 + s * 25);
+    g = Math.round(200 - s * 100);
+    b = Math.round(50 - s * 30);
+  } else {
+    const s = (t - 0.75) / 0.25;
+    r = 255;
+    g = Math.round(100 - s * 70);
+    b = Math.round(20 + s * 10);
+  }
+  return `rgba(${r},${g},${b},${alpha})`;
+}
 
 export type NetworkOverlayTransformPart = {
   x: number;
@@ -1046,7 +1080,85 @@ export function isNetworkPowerPlantSource(sourceType: string): boolean {
 }
 
 export function buildJapanGuideGraphics(): Array<Record<string, unknown>> {
-  return [];
+  // Simplified outlines of Japan's main islands as lat/lon sequences
+  const islands: Array<{ name: string; coords: Array<[number, number]> }> = [
+    {
+      name: "hokkaido",
+      coords: [
+        [43.39, 145.82], [43.33, 145.59], [43.08, 144.83], [42.92, 143.91],
+        [42.05, 142.96], [41.77, 140.73], [41.46, 140.17], [41.53, 140.66],
+        [42.32, 140.35], [42.83, 141.67], [43.17, 141.35], [43.37, 141.68],
+        [43.45, 141.7], [43.78, 142.37], [44.37, 142.46], [44.93, 142.63],
+        [45.31, 141.89], [45.43, 141.73], [45.02, 142.26], [44.79, 143.29],
+        [44.19, 144.76], [43.65, 145.45], [43.39, 145.82],
+      ],
+    },
+    {
+      name: "honshu",
+      coords: [
+        [41.45, 140.2], [41.26, 140.31], [40.52, 139.86], [39.88, 139.84],
+        [39.72, 140.05], [39.14, 139.92], [38.84, 139.55], [38.27, 138.56],
+        [37.95, 138.24], [37.31, 136.92], [36.77, 136.28], [36.34, 136.12],
+        [35.73, 135.99], [35.52, 135.7], [35.06, 135.13], [34.65, 135.25],
+        [34.26, 135.08], [33.95, 135.03], [33.51, 133.56], [33.25, 132.49],
+        [34.07, 131.88], [34.19, 131.22], [34.75, 131.73], [35.16, 132.07],
+        [35.45, 132.56], [35.42, 133.38], [35.63, 134.25], [35.55, 135.35],
+        [35.75, 136.01], [36.25, 136.62], [36.56, 136.8], [36.99, 137.17],
+        [37.55, 138.95], [37.83, 139.18], [37.65, 139.5], [37.88, 139.87],
+        [38.77, 139.82], [39.57, 140.14], [39.89, 139.84], [40.4, 139.81],
+        [40.54, 140.01], [40.87, 140.36], [41.05, 140.7], [41.26, 140.87],
+        [41.45, 140.2],
+      ],
+    },
+    {
+      name: "shikoku",
+      coords: [
+        [34.35, 134.64], [34.25, 134.18], [33.97, 133.65], [33.55, 133.27],
+        [33.02, 132.68], [32.85, 132.68], [33.15, 132.5], [33.27, 132.49],
+        [33.61, 133.03], [33.85, 133.64], [33.97, 134.3], [34.24, 134.77],
+        [34.35, 134.64],
+      ],
+    },
+    {
+      name: "kyushu",
+      coords: [
+        [33.95, 131.01], [33.58, 130.39], [33.19, 130.03], [32.72, 129.76],
+        [32.58, 130.02], [32.09, 130.3], [31.37, 131.04], [30.99, 131.04],
+        [31.21, 131.42], [31.9, 131.39], [32.66, 131.69], [32.74, 131.84],
+        [33.2, 131.73], [33.32, 131.95], [33.55, 131.17], [33.86, 130.88],
+        [33.95, 131.01],
+      ],
+    },
+    {
+      name: "okinawa",
+      coords: [
+        [26.88, 128.25], [26.71, 128.11], [26.34, 127.77], [26.09, 127.65],
+        [26.21, 127.71], [26.5, 127.94], [26.73, 128.17], [26.88, 128.25],
+      ],
+    },
+  ];
+
+  return islands.map((island) => {
+    const points = island.coords.map(([lat, lon]) => {
+      const pt = geoToCanvas(lat, lon);
+      return [pt.x, pt.y] as [number, number];
+    });
+
+    return {
+      type: "polygon",
+      z: -1,
+      silent: true,
+      shape: {
+        points,
+        smooth: 0.3,
+      },
+      style: {
+        fill: "rgba(203,213,225,0.12)",
+        stroke: "rgba(148,163,184,0.22)",
+        lineWidth: 1,
+      },
+    };
+  });
 }
 
 // Module-level computed constants (depend on the functions above)


### PR DESCRIPTION
Summary
Error boundaries: ChartErrorBoundary で各チャートセクションをラップ
Loading UI: 日付変更時のフルページスピナーオーバーレイ
Accessibility: skip-to-content、chart aria-label、section toggle aria-checked
Dark mode: system-preference ベースのダークテーマ
Japan map outline: 日本列島の簡略海岸線ポリゴンをネットワークチャート背景に描画
Flow color coding: 潮流の大きさによる青→赤のグラデーションアニメーション
Tests: 118テスト全通過