### PR TITLE
Add power flow volatility ranking visualization

### DIFF
--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -663,6 +663,118 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
     };
   }, [data.meta.slotLabels.flow, filteredLines]);
 
+  const volatilityRanking = useMemo(() => {
+    return filteredLines
+      .map((line) => {
+        const vals = line.values;
+        const n = vals.length;
+        if (n === 0) return null;
+        const mean = vals.reduce((s, v) => s + v, 0) / n;
+        const variance = vals.reduce((s, v) => s + (v - mean) ** 2, 0) / n;
+        const stdDev = Math.sqrt(variance);
+        const maxVal = Math.max(...vals);
+        const minVal = Math.min(...vals);
+        const range = maxVal - minVal;
+        return { ...line, stdDev, range, mean, maxVal, minVal };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null)
+      .sort((a, b) => b.range - a.range)
+      .slice(0, 15);
+  }, [filteredLines]);
+
+  const volatilityBarOption = useMemo(() => {
+    const items = volatilityRanking;
+    const labels = items.map((l) => `${l.area} | ${l.lineName}`);
+    return {
+      tooltip: {
+        trigger: "axis" as const,
+        axisPointer: { type: "shadow" as const },
+        formatter: (params: Array<{ seriesName: string; value: number; name: string }>) => {
+          const item = items[labels.indexOf(params[0].name)];
+          if (!item) return "";
+          return [
+            `<b>${params[0].name}</b>`,
+            `変動幅: ${numberFmt.format(Math.round(item.range))} MW`,
+            `標準偏差: ${numberFmt.format(Math.round(item.stdDev))} MW`,
+            `最大: ${numberFmt.format(Math.round(item.maxVal))} MW`,
+            `最小: ${numberFmt.format(Math.round(item.minVal))} MW`,
+            `平均: ${numberFmt.format(Math.round(item.mean))} MW`,
+          ].join("<br/>");
+        },
+      },
+      grid: { top: 20, left: 160, right: 60, bottom: 30 },
+      xAxis: {
+        type: "value" as const,
+        name: "MW",
+        axisLabel: { formatter: (v: number) => numberFmt.format(v) },
+      },
+      yAxis: {
+        type: "category" as const,
+        data: [...labels].reverse(),
+        axisLabel: { fontSize: 11 },
+      },
+      series: [
+        {
+          name: "変動幅",
+          type: "bar",
+          data: [...items].reverse().map((l) => ({
+            value: Math.round(l.range),
+            itemStyle: { color: FLOW_AREA_COLORS[l.area] ?? FLOW_AREA_COLORS.default },
+          })),
+          barMaxWidth: 18,
+          label: {
+            show: true,
+            position: "right" as const,
+            fontSize: 10,
+            formatter: (p: { value: number }) => `${numberFmt.format(p.value)}`,
+          },
+        },
+      ],
+    };
+  }, [volatilityRanking]);
+
+  const volatilitySparkOption = useMemo(() => {
+    const items = volatilityRanking.slice(0, 10);
+    const slotLabels = data.meta.slotLabels.flow;
+    return {
+      tooltip: {
+        trigger: "axis" as const,
+        formatter: (params: Array<{ seriesName: string; data: number; dataIndex: number }>) => {
+          const time = slotLabels[params[0].dataIndex] ?? "";
+          return params
+            .map((p) => `${p.seriesName}: ${numberFmt.format(Math.round(p.data))} MW`)
+            .join("<br/>")
+            + `<br/><span style="color:#999">${time}</span>`;
+        },
+      },
+      legend: {
+        type: "scroll" as const,
+        bottom: 0,
+        textStyle: { fontSize: 10 },
+      },
+      grid: { top: 10, left: 50, right: 20, bottom: 40 },
+      xAxis: {
+        type: "category" as const,
+        data: slotLabels,
+        axisLabel: { interval: 5, fontSize: 10 },
+        boundaryGap: false,
+      },
+      yAxis: {
+        type: "value" as const,
+        axisLabel: { fontSize: 10, formatter: (v: number) => numberFmt.format(v) },
+      },
+      series: items.map((line, idx) => ({
+        name: `${line.area}|${line.lineName}`,
+        type: "line" as const,
+        data: line.values.map((v) => Math.round(v)),
+        smooth: true,
+        symbol: "none",
+        lineStyle: { width: 1.5 },
+        color: SOURCE_COLORS[idx % SOURCE_COLORS.length],
+      })),
+    };
+  }, [volatilityRanking, data.meta.slotLabels.flow]);
+
   const flowNetworkOption = useMemo(() => {
     type NetworkLink = {
       kind: "intra";
@@ -2362,6 +2474,21 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
             <Panel title="主要線路の潮流ヒートマップ">
               <p className="mb-2 text-xs text-slate-500">主要線路の時間帯別の潮流強度を俯瞰します。</p>
               <ReactECharts option={flowHeatmapOption} style={{ height: 420 }} />
+            </Panel>
+          </section>
+          </ChartErrorBoundary>
+        ) : null}
+
+        {visibleSectionSet.has("diagnostics") ? (
+          <ChartErrorBoundary sectionName="潮流変動ランキング">
+          <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <Panel title="潮流変動が大きい送電線">
+              <p className="mb-2 text-xs text-slate-500">一日の潮流の変動幅（最大−最小）が大きい上位15線路。</p>
+              <ReactECharts option={volatilityBarOption} style={{ height: 440 }} />
+            </Panel>
+            <Panel title="高変動線路の時間推移">
+              <p className="mb-2 text-xs text-slate-500">変動上位10線路の30分値推移を重ねて表示します。</p>
+              <ReactECharts option={volatilitySparkOption} style={{ height: 440 }} />
             </Panel>
           </section>
           </ChartErrorBoundary>


### PR DESCRIPTION
## Summary
Added a new diagnostics section to the dashboard that visualizes power flow volatility across transmission lines. This includes:

1. **Volatility Ranking Calculation** (`volatilityRanking`): Computes statistical metrics (standard deviation, range, min/max, mean) for each filtered transmission line and ranks the top 15 by daily range (max - min).

2. **Bar Chart Visualization** (`volatilityBarOption`): Displays the top 15 most volatile lines as a horizontal bar chart sorted by range, with color-coding by area and detailed tooltip information.

3. **Time Series Overlay** (`volatilitySparkOption`): Shows the 30-minute value trends for the top 10 most volatile lines in a line chart, allowing comparison of volatility patterns over time.

4. **UI Components**: Added a new "潮流変動ランキング" (Power Flow Volatility Ranking) section with two panels under the diagnostics visibility toggle.

## Scope
- **In**: 
  - New `volatilityRanking` memoized computation
  - New `volatilityBarOption` and `volatilitySparkOption` chart configurations
  - New UI section with two chart panels
  - Integrated with existing visibility section controls and error boundaries

- **Out**: 
  - No changes to existing data structures or other visualizations
  - No changes to filtering or data processing logic

## Checklist
- [ ] Branch name includes Linear ID (`feature/GRID-xxx-*`)
- [ ] Commit messages include Linear ID
- [ ] `npm run lint` passed
- [ ] `npm run build` passed
- [ ] Screenshots attached for UI changes

## Verification
1. Verify the "潮流変動ランキング" section appears when diagnostics visibility is enabled
2. Confirm the bar chart correctly ranks lines by daily range and displays accurate statistics in tooltips
3. Verify the time series chart displays the top 10 volatile lines with proper legend and time labels

https://claude.ai/code/session_01TgGKNqzyN6pGz7CbTaAMut