### PR TITLE
Adjust data refresh schedule to run 4 times daily

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -30,10 +30,10 @@ on:
         default: false
         type: boolean
   schedule:
-    # 09:10 / 15:10 / 18:10 JST: intraday snapshot for today + yesterday
-    - cron: "10 0,6,9 * * *"
-    # 11:10 / 16:10 / 21:10 JST (02:10 / 07:10 / 12:10 UTC): refresh recent fixed datasets
-    - cron: "10 2,7,12 * * *"
+    # 09:10 / 12:10 / 15:10 / 18:10 JST: intraday snapshot for today + yesterday
+    - cron: "10 0,3,6,9 * * *"
+    # 11:10 / 13:10 / 16:10 / 21:10 JST: refresh recent fixed datasets
+    - cron: "10 2,4,7,12 * * *"
 
 permissions:
   contents: write
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            if [ "${{ github.event.schedule }}" = "10 2,7,12 * * *" ]; then
+            if [ "${{ github.event.schedule }}" = "10 2,4,7,12 * * *" ]; then
               FROM="$(TZ=Asia/Tokyo date -d '4 days ago' '+%Y-%m-%d')"
               TO="$(TZ=Asia/Tokyo date -d '1 day ago' '+%Y-%m-%d')"
               echo "Scheduled fixed-data refresh for recent dates: ${FROM}..${TO}"


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow schedule to increase the frequency of data refresh jobs from 3 to 4 times daily, with adjusted UTC cron times to maintain proper JST alignment.

## Changes
- **Intraday snapshot schedule**: Added an additional run at 12:10 JST (03:00 UTC)
  - Previous: 3 runs at 09:10 / 15:10 / 18:10 JST
  - Updated: 4 runs at 09:10 / 12:10 / 15:10 / 18:10 JST
  - Cron: `10 0,3,6,9 * * *` (was `10 0,6,9 * * *`)

- **Fixed dataset refresh schedule**: Added an additional run at 13:10 JST (04:00 UTC)
  - Previous: 3 runs at 11:10 / 16:10 / 21:10 JST
  - Updated: 4 runs at 11:10 / 13:10 / 16:10 / 21:10 JST
  - Cron: `10 2,4,7,12 * * *` (was `10 2,7,12 * * *`)

- Updated the schedule condition check in the workflow to match the new fixed dataset refresh cron expression

## Scope
- **In**: GitHub Actions workflow scheduling configuration
- **Out**: No changes to job logic or data processing

## Verification
- Cron expressions validated for correct UTC to JST conversion
- Schedule condition check updated to match new cron pattern

https://claude.ai/code/session_017xTwwwZm5Ge2U91J3wg75M