### PR TITLE
Fix fetchedAt label to use initialData instead of data

### DIFF
--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -90,7 +90,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
   const [viewportWidth, setViewportWidth] = useState<number>(1280);
   const isMobileViewport = viewportWidth < 768;
   const useInlineDonutLegend = viewportWidth >= 1024;
-  const fetchedAtLabel = useMemo(() => formatJstDateTime(data.meta.fetchedAt), [data.meta.fetchedAt]);
+  const fetchedAtLabel = useMemo(() => formatJstDateTime(initialData.meta.fetchedAt), [initialData.meta.fetchedAt]);
 
   useEffect(() => {
     const updateViewportWidth = (): void => {


### PR DESCRIPTION
## Summary
- Fixed a bug where `fetchedAtLabel` was using `data.meta.fetchedAt` instead of `initialData.meta.fetchedAt` in the dependency array and calculation

## Scope
- In: `src/components/dashboard-app.tsx` - Updated `useMemo` hook to reference `initialData` consistently
- Out: No other components affected

## Details
The `fetchedAtLabel` memoization was referencing `data.meta.fetchedAt` which could cause stale values or unnecessary recalculations. Changed to use `initialData.meta.fetchedAt` to match the intended data source and ensure the dependency array is correct.

## Checklist
- [ ] Branch name includes Linear ID (`feature/GRID-xxx-*`)
- [ ] Commit messages include Linear ID
- [ ] `npm run lint` passed
- [ ] `npm run build` passed
- [ ] Screenshots attached for UI changes

## Verification
- Existing tests pass with the corrected reference
- No UI changes expected; this is a data source correction

https://claude.ai/code/session_01KZ5adCypZkgEzWza31SGrG