### PR TITLE
fix: prevent reserve rate label from overlapping legend

### DIFF
--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -241,7 +241,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
         type: "scroll",
         textStyle: { color: "#334155" },
       },
-      grid: { top: 48, left: 52, right: 18, bottom: 34 },
+      grid: { top: 60, left: 52, right: 18, bottom: 34 },
       xAxis: {
         type: "category",
         data: data.meta.slotLabels.generation,
@@ -250,6 +250,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
       yAxis: {
         type: "value",
         name: "予備率(%)",
+        nameGap: 10,
         axisLabel: {
           formatter: (value: number) => decimalFmt.format(value),
         },


### PR DESCRIPTION
Increase grid.top from 48 to 60 and add nameGap: 10 to the yAxis in the reserve trend chart so the "予備率(%)" label no longer collides with the scrollable legend row above it.

https://claude.ai/code/session_01KZ5adCypZkgEzWza31SGrG

## Linear
- Issue: `GRID-xxx`
- Link: https://linear.app/<workspace>/issue/GRID-xxx

## Summary
- 

## Scope
- In:
- Out:

## Checklist
- [ ] Branch name includes Linear ID (`feature/GRID-xxx-*`)
- [ ] Commit messages include Linear ID
- [ ] `npm run lint` passed
- [ ] `npm run build` passed
- [ ] Screenshots attached for UI changes

## Verification
1. 
2. 
