### PR TITLE
タイトル変更と潮流ヒートマップの凡例位置を修正

### DIFF
--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -626,7 +626,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
           return `${yLabels[row]}<br/>${data.meta.slotLabels.flow[col]}: ${numberFmt.format(value)} MW`;
         },
       },
-      grid: { top: 20, left: 160, right: 20, bottom: 44 },
+      grid: { top: 20, left: 160, right: 80, bottom: 20 },
       xAxis: {
         type: "category",
         data: data.meta.slotLabels.flow,
@@ -642,9 +642,9 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
         min: -800,
         max: 800,
         calculable: true,
-        orient: "horizontal",
-        left: "center",
-        bottom: 0,
+        orient: "vertical",
+        right: 0,
+        top: 0,
         inRange: {
           color: ["#0b132b", "#1c2541", "#4f772d", "#f77f00", "#d62828"],
         },
@@ -711,7 +711,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
           ].join("<br/>");
         },
       },
-      grid: { top: 20, left: 220, right: 20, bottom: 44 },
+      grid: { top: 20, left: 220, right: 80, bottom: 20 },
       xAxis: {
         type: "category",
         data: data.meta.slotLabels.flow,
@@ -728,9 +728,9 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
         min: -150,
         max: 150,
         calculable: true,
-        orient: "horizontal",
-        left: "center",
-        bottom: 0,
+        orient: "vertical",
+        right: 0,
+        top: 0,
         text: ["+150%", "−150%"],
         inRange: {
           color: ["#1d4877", "#4a7fb5", "#98d1d1", "#fcfcfc", "#f4a261", "#e76f51", "#9b2226"],
@@ -1882,7 +1882,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
             <div>
               <p className="text-xs tracking-[0.18em] text-teal-700 dark:text-teal-400">OCCTO GRID OBSERVATORY</p>
               <h1 className="text-2xl font-semibold leading-tight md:text-3xl">
-                送電潮流 × ユニット発電実績 ダッシュボード
+                発電実績 ×送電潮流実績 ダッシュボード
               </h1>
               <p className="text-sm text-slate-600 dark:text-slate-400">
                 対象日: {data.meta.targetDate} / 最終取り込み: {fetchedAtLabel}

--- a/tests/helpers/dashboard.ts
+++ b/tests/helpers/dashboard.ts
@@ -30,7 +30,7 @@ export async function waitForChartSurface(locator: Locator): Promise<void> {
 
 export async function waitForDashboardReady(page: Page): Promise<void> {
   await page.goto("./");
-  await expect(page.getByRole("heading", { level: 1, name: "送電潮流 × ユニット発電実績 ダッシュボード" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "発電実績 ×送電潮流実績 ダッシュボード" })).toBeVisible();
   await waitForChartSurface(page.getByTestId("generation-trend-chart"));
   await waitForChartSurface(page.getByTestId("reserve-trend-chart"));
   await waitForChartSurface(page.getByTestId("reserve-current-chart"));


### PR DESCRIPTION
- ダッシュボードタイトルを「発電実績 ×送電潮流実績 ダッシュボード」に変更
- 主要線路の潮流ヒートマップと潮流変動率ヒートマップの visualMapをグラフ右上に縦配置に変更し、ラベルとの重なりを解消

https://claude.ai/code/session_01JrGQGW5s51J2EJBsFo4GCP

## Linear
- Issue: `GRID-xxx`
- Link: https://linear.app/<workspace>/issue/GRID-xxx

## Summary
- 

## Scope
- In:
- Out:

## Checklist
- [ ] Branch name includes Linear ID (`feature/GRID-xxx-*`)
- [ ] Commit messages include Linear ID
- [ ] `npm run lint` passed
- [ ] `npm run build` passed
- [ ] Screenshots attached for UI changes

## Verification
1. 
2. 
