### PR TITLE
fix: make time slider sticky so it stays visible while scrolling

### DIFF
--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -2257,7 +2257,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
         ) : null}
 
         {/* ── 表示時刻スナップショット ── */}
-        <section className="rounded-3xl border border-teal-200/60 bg-gradient-to-r from-teal-50/80 to-white/80 px-5 py-4 shadow-sm backdrop-blur dark:border-teal-800/60 dark:from-teal-950/30 dark:to-slate-800/80">
+        <section className="sticky top-0 z-30 rounded-3xl border border-teal-200/60 bg-gradient-to-r from-teal-50/95 to-white/95 px-5 py-4 shadow-md backdrop-blur-sm dark:border-teal-800/60 dark:from-teal-950/95 dark:to-slate-800/95">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
               <h2 className="text-base font-semibold text-teal-800 dark:text-teal-300">表示時刻スナップショット</h2>


### PR DESCRIPTION
The time-slot snapshot section can be taller than the viewport, making the slider inaccessible when scrolling down. Apply sticky positioning with z-30 and increased background opacity so the slider remains fixed at the top and always operable.

https://claude.ai/code/session_01KZ5adCypZkgEzWza31SGrG

## Linear
- Issue: `GRID-xxx`
- Link: https://linear.app/<workspace>/issue/GRID-xxx

## Summary
- 

## Scope
- In:
- Out:

## Checklist
- [ ] Branch name includes Linear ID (`feature/GRID-xxx-*`)
- [ ] Commit messages include Linear ID
- [ ] `npm run lint` passed
- [ ] `npm run build` passed
- [ ] Screenshots attached for UI changes

## Verification
1. 
2. 
