### PR TITLE
Enable drop swap mode in SwapyContainer

### DIFF
--- a/src/components/ui/swapy-container.tsx
+++ b/src/components/ui/swapy-container.tsx
@@ -27,6 +27,7 @@ export function SwapyContainer({
 
     const swapy = createSwapy(containerRef.current, {
       manualSwap: true,
+      swapMode: "drop",
       animation: "dynamic",
       dragAxis: "y",
       dragOnHold: true,


### PR DESCRIPTION
## Linear
- Issue: `GRID-xxx`
- Link: https://linear.app/<workspace>/issue/GRID-xxx

## Summary
- Enable drop-based swap mode in the Swapy container configuration to improve drag-and-drop interaction behavior

## Scope
- In: SwapyContainer component initialization
- Out: N/A

## Changes
Updated the Swapy configuration to use `swapMode: "drop"` instead of the default swap mode. This ensures that swap operations are triggered on drop events rather than during drag, providing more predictable and user-friendly drag-and-drop interactions.

## Checklist
- [ ] Branch name includes Linear ID (`feature/GRID-xxx-*`)
- [ ] Commit messages include Linear ID
- [ ] `npm run lint` passed
- [ ] `npm run build` passed
- [ ] Screenshots attached for UI changes

## Verification
1. Test drag-and-drop interactions in the SwapyContainer to confirm swaps occur on drop
2. Verify no regressions in existing drag-and-drop functionality

https://claude.ai/code/session_01HdcWog8bf1hJ7ED6Vxewz9