### PR TITLE
perf(dashboard): memoize sections and split network-flow topology (P0)

### DIFF
--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { DashboardData } from "@/lib/dashboard-types";
 import {
   SOURCE_COLORS,
@@ -17,7 +17,6 @@ import {
   compareAreaOrder,
 } from "@/lib/formatters";
 import {
-  type NetworkAnimationPath,
   type NetworkOverlayViewport,
   type NetworkFlowChartHostElement,
   DEFAULT_NETWORK_OVERLAY_VIEWPORT,
@@ -48,7 +47,10 @@ import {
   buildCongestionHeatmapOption,
   type CongestionSummary,
 } from "@/lib/chart-options";
-import { buildFlowNetworkOption } from "@/lib/network-flow-builder";
+import {
+  buildFlowNetworkOption,
+  buildFlowNetworkTopology,
+} from "@/lib/network-flow-builder";
 import { FOOTER_LINK_CLASS } from "@/lib/styles";
 import {
   buildAllPlantSummaries,
@@ -132,6 +134,8 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
     setIsReorderMode,
   } = useSectionOrder();
 
+  const toggleReorderMode = useCallback(() => setIsReorderMode((v) => !v), [setIsReorderMode]);
+
   const isBlockVisible = (blockId: DashboardBlockId): boolean => {
     const def = [...ZONE_A_BLOCKS, ...ZONE_B_BLOCKS].find((b) => b.blockId === blockId);
     if (!def) return false;
@@ -158,7 +162,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
   const [networkOverlayViewport, setNetworkOverlayViewport] = useState<NetworkOverlayViewport>(
     DEFAULT_NETWORK_OVERLAY_VIEWPORT,
   );
-  const syncNetworkOverlayViewport = (chart: unknown): void => {
+  const syncNetworkOverlayViewport = useCallback((chart: unknown): void => {
     const nextViewport = readNetworkOverlayViewport(chart);
     if (!nextViewport) {
       return;
@@ -166,11 +170,11 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
     setNetworkOverlayViewport((currentViewport) =>
       areNetworkOverlayViewportsEqual(currentViewport, nextViewport) ? currentViewport : nextViewport,
     );
-  };
-  const registerNetworkFlowChart = (chart: unknown): void => {
+  }, []);
+  const registerNetworkFlowChart = useCallback((chart: unknown): void => {
     attachNetworkFlowChartRoamHook(chart, networkFlowChartHostRef.current);
     syncNetworkOverlayViewport(chart);
-  };
+  }, [syncNetworkOverlayViewport]);
   useEffect(() => {
     const chartHost = networkFlowChartHostRef.current;
     return () => {
@@ -344,37 +348,30 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
     [data.meta.slotLabels.flow, filteredLines, isMobileViewport, isDark],
   );
 
-  const flowNetworkOption = useMemo(
-    () => buildFlowNetworkOption({
-      areaSummaries: data.flows.areaSummaries,
-      filteredIntertieSeries,
-      lineSeries: data.flows.lineSeries,
-      clampedNetworkFlowSlotIndex,
-      networkPowerPlants,
-      selectedFlowDateTimeLabel,
-      maxAnimatedFlowLinesPerArea,
-    }),
-    [data.flows.areaSummaries, filteredIntertieSeries, data.flows.lineSeries, clampedNetworkFlowSlotIndex, networkPowerPlants, selectedFlowDateTimeLabel, maxAnimatedFlowLinesPerArea],
-  );
-  const majorFlowAnimationPaths = useMemo(
+  const flowNetworkTopology = useMemo(
     () =>
-      (
-        flowNetworkOption as {
-          __majorFlowAnimationPaths?: NetworkAnimationPath[];
-        }
-      ).__majorFlowAnimationPaths ?? [],
-    [flowNetworkOption],
+      buildFlowNetworkTopology({
+        areaSummaries: data.flows.areaSummaries,
+        filteredIntertieSeries,
+        lineSeries: data.flows.lineSeries,
+        networkPowerPlants,
+      }),
+    [data.flows.areaSummaries, filteredIntertieSeries, data.flows.lineSeries, networkPowerPlants],
   );
-
-  const intertieAnimationPaths = useMemo(
+  const flowNetworkResult = useMemo(
     () =>
-      (
-        flowNetworkOption as {
-          __intertieAnimationPaths?: NetworkAnimationPath[];
-        }
-      ).__intertieAnimationPaths ?? [],
-    [flowNetworkOption],
+      buildFlowNetworkOption(flowNetworkTopology, {
+        lineSeries: data.flows.lineSeries,
+        filteredIntertieSeries,
+        clampedNetworkFlowSlotIndex,
+        selectedFlowDateTimeLabel,
+        maxAnimatedFlowLinesPerArea,
+      }),
+    [flowNetworkTopology, data.flows.lineSeries, filteredIntertieSeries, clampedNetworkFlowSlotIndex, selectedFlowDateTimeLabel, maxAnimatedFlowLinesPerArea],
   );
+  const flowNetworkOption = flowNetworkResult.option;
+  const majorFlowAnimationPaths = flowNetworkResult.majorFlowAnimationPaths;
+  const intertieAnimationPaths = flowNetworkResult.intertieAnimationPaths;
 
   const japanGuidePaths = useMemo(() => buildJapanGuideSvgPaths(), []);
 
@@ -520,7 +517,7 @@ export function DashboardApp({ initialData, availableDates }: DashboardAppProps)
           visibleSectionSet={visibleSectionSet}
           onSetVisibleSectionIds={setVisibleSectionIds}
           isReorderMode={isReorderMode}
-          onToggleReorderMode={() => setIsReorderMode((v) => !v)}
+          onToggleReorderMode={toggleReorderMode}
           onResetOrder={resetOrder}
         />
 

--- a/src/components/sections/area-cards-section.tsx
+++ b/src/components/sections/area-cards-section.tsx
@@ -14,7 +14,7 @@ import {
   NetFlowMeter,
 } from "@/components/ui/dashboard-ui";
 import dynamic from "next/dynamic";
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 
 const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
 
@@ -124,7 +124,7 @@ function buildSupplyDemandSparkline(
   };
 }
 
-export function AreaCardsSection({
+function AreaCardsSectionImpl({
   areaSupplyCards,
   selectedArea,
   selectedFlowSlotLabel,
@@ -323,3 +323,5 @@ export function AreaCardsSection({
     </section>
   );
 }
+
+export const AreaCardsSection = memo(AreaCardsSectionImpl);

--- a/src/components/sections/congestion-section.tsx
+++ b/src/components/sections/congestion-section.tsx
@@ -1,4 +1,5 @@
 import dynamic from "next/dynamic";
+import { memo } from "react";
 import type { CongestionSummary } from "@/lib/chart-options";
 import { CompactStatCard, Panel } from "@/components/ui/dashboard-ui";
 import { numberFmt, decimalFmt } from "@/lib/formatters";
@@ -11,7 +12,7 @@ type CongestionSectionProps = {
   congestionHeatmapOption: Record<string, unknown> | null;
 };
 
-export function CongestionSection({
+function CongestionSectionImpl({
   congestionData,
   congestionTrendOption,
   congestionHeatmapOption,
@@ -110,3 +111,5 @@ export function CongestionSection({
     </section>
   );
 }
+
+export const CongestionSection = memo(CongestionSectionImpl);

--- a/src/components/sections/dashboard-header.tsx
+++ b/src/components/sections/dashboard-header.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import {
   DASHBOARD_SECTION_OPTIONS,
   type DashboardSectionId,
@@ -28,7 +29,7 @@ type DashboardHeaderProps = {
   onAreaChange: (area: string) => void;
 };
 
-export function DashboardHeader({
+function DashboardHeaderImpl({
   targetDate,
   fetchedAtLabel,
   selectedDate,
@@ -140,7 +141,7 @@ type SectionToggleProps = {
   onResetOrder: () => void;
 };
 
-export function SectionToggle({ visibleSectionSet, onSetVisibleSectionIds, isReorderMode, onToggleReorderMode, onResetOrder }: SectionToggleProps) {
+function SectionToggleImpl({ visibleSectionSet, onSetVisibleSectionIds, isReorderMode, onToggleReorderMode, onResetOrder }: SectionToggleProps) {
   return (
     <section className="animate-fade-in-up rounded-3xl border border-slate-200/80 bg-white p-3 shadow-sm md:p-5 dark:border-slate-700/80 dark:bg-slate-800" style={{ animationDelay: '80ms' }}>
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -217,3 +218,6 @@ export function SectionToggle({ visibleSectionSet, onSetVisibleSectionIds, isReo
     </section>
   );
 }
+
+export const DashboardHeader = memo(DashboardHeaderImpl);
+export const SectionToggle = memo(SectionToggleImpl);

--- a/src/components/sections/generation-section.tsx
+++ b/src/components/sections/generation-section.tsx
@@ -1,4 +1,5 @@
 import dynamic from "next/dynamic";
+import { memo } from "react";
 import { Panel, CompositionLegendList } from "@/components/ui/dashboard-ui";
 import { ChartErrorBoundary } from "@/components/ui/error-boundary";
 import { SELECT_COMPACT_CLASS } from "@/lib/styles";
@@ -19,7 +20,7 @@ type GenerationSectionProps = {
   useInlineDonutLegend: boolean;
 };
 
-export function GenerationSection({
+function GenerationSectionImpl({
   showGenerationTrend,
   showSourceComposition,
   generationTrendArea,
@@ -105,3 +106,5 @@ export function GenerationSection({
     </ChartErrorBoundary>
   );
 }
+
+export const GenerationSection = memo(GenerationSectionImpl);

--- a/src/components/sections/generator-status-section.tsx
+++ b/src/components/sections/generator-status-section.tsx
@@ -8,7 +8,7 @@ import {
   type AreaGenerationSeries,
 } from "@/lib/chart-options";
 import dynamic from "next/dynamic";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
 const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
@@ -251,7 +251,7 @@ function ExpandedCardModal({
 /*  Main Section                                                      */
 /* ------------------------------------------------------------------ */
 
-export function GeneratorStatusSection({
+function GeneratorStatusSectionImpl({
   cards,
   treemapItems,
   selectedArea,
@@ -460,3 +460,5 @@ export function GeneratorStatusSection({
     </section>
   );
 }
+
+export const GeneratorStatusSection = memo(GeneratorStatusSectionImpl);

--- a/src/components/sections/jepx-market-section.tsx
+++ b/src/components/sections/jepx-market-section.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import {
   SummaryCard,
   CompactStatCard,
@@ -120,7 +121,7 @@ type JepxMarketCardProps = {
   clampedSlotIndex: number;
 };
 
-export function JepxMarketCard({
+function JepxMarketCardImpl({
   spot,
   slotLabels,
   selectedArea,
@@ -243,7 +244,7 @@ type JepxAreaBreakdownProps = {
   slotLabels: string[];
 };
 
-export function JepxAreaBreakdown({ spot }: JepxAreaBreakdownProps) {
+function JepxAreaBreakdownImpl({ spot }: JepxAreaBreakdownProps) {
   const highlights = buildJepxHighlights(spot);
 
   if (highlights.areaPriceItems.length === 0) return null;
@@ -263,3 +264,6 @@ export function JepxAreaBreakdown({ spot }: JepxAreaBreakdownProps) {
     </SummaryCard>
   );
 }
+
+export const JepxMarketCard = memo(JepxMarketCardImpl);
+export const JepxAreaBreakdown = memo(JepxAreaBreakdownImpl);

--- a/src/components/sections/network-section.tsx
+++ b/src/components/sections/network-section.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic";
-import { type MutableRefObject, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, type MutableRefObject, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { buildExpandedFlowNetworkOption } from "@/lib/network-flow-builder";
 import type {
@@ -285,7 +285,7 @@ function IntertieAnimationPaths({ paths }: { paths: NetworkAnimationPath[] }) {
 /*  Main Section                                                      */
 /* ------------------------------------------------------------------ */
 
-export function NetworkSection({
+function NetworkSectionImpl({
   flowNetworkOption,
   interAreaFlowOption,
   isMobileViewport,
@@ -482,3 +482,5 @@ export function NetworkSection({
     </section>
   );
 }
+
+export const NetworkSection = memo(NetworkSectionImpl);

--- a/src/components/sections/rankings-section.tsx
+++ b/src/components/sections/rankings-section.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { TopUnit } from "@/lib/dashboard-types";
 import type { PlantSummaryRow } from "@/lib/dashboard-computations";
 import { FLOW_AREA_COLORS } from "@/lib/constants";
@@ -9,7 +10,7 @@ type RankingsSectionProps = {
   filteredTopPlants: PlantSummaryRow[];
 };
 
-export function RankingsSection({
+function RankingsSectionImpl({
   filteredTopUnits,
   filteredTopPlants,
 }: RankingsSectionProps) {
@@ -97,3 +98,5 @@ export function RankingsSection({
     </section>
   );
 }
+
+export const RankingsSection = memo(RankingsSectionImpl);

--- a/src/components/sections/summary-cards-section.tsx
+++ b/src/components/sections/summary-cards-section.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import {
   SummaryCard,
   CompactStatCard,
@@ -20,7 +21,7 @@ type SummaryCardsTopProps = {
   areaTotalsLength: number;
 };
 
-export function SummaryCardsTop({ dashboardHighlights, areaTotalsLength }: SummaryCardsTopProps) {
+function SummaryCardsTopImpl({ dashboardHighlights, areaTotalsLength }: SummaryCardsTopProps) {
   return (
     <section className="stagger-children grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
       <SummaryCard
@@ -94,7 +95,7 @@ type SummaryCardsBottomProps = {
   selectedFlowDateTimeLabel: string;
 };
 
-export function SummaryCardsBottom({ dashboardHighlights, selectedFlowDateTimeLabel }: SummaryCardsBottomProps) {
+function SummaryCardsBottomImpl({ dashboardHighlights, selectedFlowDateTimeLabel }: SummaryCardsBottomProps) {
   return (
     <section className="stagger-children grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
       <SummaryCard
@@ -158,3 +159,6 @@ export function SummaryCardsBottom({ dashboardHighlights, selectedFlowDateTimeLa
     </section>
   );
 }
+
+export const SummaryCardsTop = memo(SummaryCardsTopImpl);
+export const SummaryCardsBottom = memo(SummaryCardsBottomImpl);

--- a/src/lib/network-flow-builder.ts
+++ b/src/lib/network-flow-builder.ts
@@ -3,11 +3,17 @@
  *
  * Data extraction logic is in network-flow-data.ts; this module focuses on
  * assembling the final chart configuration.
+ *
+ * Topology (slot-independent node layout, degrees, station positions) is
+ * computed once per dataset via `buildFlowNetworkTopology` and reused across
+ * time-slider slot changes. Per-slot work (link values, intertie aggregates,
+ * animation paths) is done in `buildFlowNetworkOption`.
  */
 
 import type { DashboardData } from "@/lib/dashboard-types";
 import { FLOW_AREA_COLORS, MAX_ANIMATED_FLOW_LINES_PER_AREA, MAP_VIEWBOX } from "@/lib/constants";
 import { numberFmt, decimalFmt, formatVoltageKv } from "@/lib/formatters";
+import type { NetworkAnimationPath } from "@/lib/geo-viewport";
 import {
   extractIntraAreaLinks,
   extractIntertieData,
@@ -22,7 +28,7 @@ import {
 } from "@/lib/network-flow-data";
 // Japan guide graphics are now rendered via SVG overlay in the component
 
-export type NetworkFlowBuilderParams = {
+export type NetworkFlowTopologyParams = {
   areaSummaries: DashboardData["flows"]["areaSummaries"];
   filteredIntertieSeries: Array<{
     intertieName: string;
@@ -33,7 +39,6 @@ export type NetworkFlowBuilderParams = {
     values: number[];
   }>;
   lineSeries: DashboardData["flows"]["lineSeries"];
-  clampedNetworkFlowSlotIndex: number;
   networkPowerPlants: Array<{
     area: string;
     plantName: string;
@@ -42,45 +47,62 @@ export type NetworkFlowBuilderParams = {
     avgOutputMw: number;
     maxOutputManKw: number;
   }>;
+};
+
+export type NetworkFlowSlotParams = {
+  lineSeries: DashboardData["flows"]["lineSeries"];
+  filteredIntertieSeries: NetworkFlowTopologyParams["filteredIntertieSeries"];
+  clampedNetworkFlowSlotIndex: number;
   selectedFlowDateTimeLabel: string;
   maxAnimatedFlowLinesPerArea?: number;
 };
 
+export type NetworkFlowBuilderParams = NetworkFlowTopologyParams & NetworkFlowSlotParams;
+
+export type FlowNetworkTopology = {
+  nodes: Array<Record<string, unknown>>;
+  nodePointById: Map<string, { x: number; y: number }>;
+  areaCategories: string[];
+  categoryIndex: Map<string, number>;
+  stationPositions: Map<string, { x: number; y: number }>;
+  areaScope: Set<string>;
+};
+
+export type FlowNetworkResult = {
+  option: Record<string, unknown>;
+  majorFlowAnimationPaths: NetworkAnimationPath[];
+  intertieAnimationPaths: NetworkAnimationPath[];
+};
+
 export type { NetworkLink } from "@/lib/network-flow-data";
 
-export function buildFlowNetworkOption(params: NetworkFlowBuilderParams) {
-  const {
-    areaSummaries,
-    filteredIntertieSeries,
-    lineSeries,
-    clampedNetworkFlowSlotIndex,
-    networkPowerPlants,
-    selectedFlowDateTimeLabel,
-    maxAnimatedFlowLinesPerArea = MAX_ANIMATED_FLOW_LINES_PER_AREA,
-  } = params;
+/**
+ * Build the slot-independent topology (node layout, positions, categories).
+ * Memoize this by dataset inputs — recomputing is expensive and unnecessary
+ * when only the time-slider slot index changes.
+ */
+export function buildFlowNetworkTopology(params: NetworkFlowTopologyParams): FlowNetworkTopology {
+  const { areaSummaries, filteredIntertieSeries, lineSeries, networkPowerPlants } = params;
 
-  // 1. Extract intra-area links
-  const { links, visibleAreas, stationsByArea, nodeDegree } = extractIntraAreaLinks(
-    lineSeries,
-    clampedNetworkFlowSlotIndex,
-  );
+  // Run extract functions with slot 0 to populate stationsByArea / nodeDegree /
+  // visibleAreas. These outputs are direction-agnostic (both endpoints are
+  // always added regardless of flow sign), so they are slot-independent.
+  const { visibleAreas, stationsByArea, nodeDegree } = extractIntraAreaLinks(lineSeries, 0);
 
-  // 2. Extract intertie data
   const areaScope = new Set<string>();
   lineSeries.forEach((line) => areaScope.add(line.area));
   if (areaScope.size === 0) {
     areaSummaries.forEach((row) => areaScope.add(row.area));
   }
 
-  const { intertieFacilityMap, intertieBridgeMap } = extractIntertieData(
+  extractIntertieData(
     filteredIntertieSeries,
-    clampedNetworkFlowSlotIndex,
+    0,
     visibleAreas,
     stationsByArea,
     nodeDegree,
   );
 
-  // 3. Build station positions and nodes
   const stationPositions = buildStationLayout(stationsByArea);
 
   if (visibleAreas.size === 0) {
@@ -99,9 +121,8 @@ export function buildFlowNetworkOption(params: NetworkFlowBuilderParams) {
     areaScope,
   );
 
-  // 3b. Add invisible anchor nodes at MAP_VIEWBOX corners to pin the coordinate range.
-  // Without these, ECharts auto-ranges to the data extent and the SVG overlay
-  // (Japan map + animation paths) becomes misaligned.
+  // Invisible anchor nodes at MAP_VIEWBOX corners pin the coordinate range so
+  // ECharts auto-ranging keeps the SVG overlay aligned.
   nodes.push(
     {
       id: "__anchor_topLeft",
@@ -127,10 +148,6 @@ export function buildFlowNetworkOption(params: NetworkFlowBuilderParams) {
     },
   );
 
-  // 4. Build rendered links
-  const renderedLinks = buildRenderedLinks(links, stationPositions);
-
-  // 5. Build intertie lines
   const nodePointById = new Map<string, { x: number; y: number }>();
   nodes.forEach((node) => {
     const id = String(node.id ?? "");
@@ -141,18 +158,58 @@ export function buildFlowNetworkOption(params: NetworkFlowBuilderParams) {
     }
   });
 
+  return {
+    nodes,
+    nodePointById,
+    areaCategories,
+    categoryIndex,
+    stationPositions,
+    areaScope,
+  };
+}
+
+/**
+ * Build the per-slot chart option and animation paths from a prebuilt topology.
+ * Cheap enough to recompute on every time-slider change.
+ */
+export function buildFlowNetworkOption(
+  topology: FlowNetworkTopology,
+  params: NetworkFlowSlotParams,
+): FlowNetworkResult {
+  const {
+    lineSeries,
+    filteredIntertieSeries,
+    clampedNetworkFlowSlotIndex,
+    selectedFlowDateTimeLabel,
+    maxAnimatedFlowLinesPerArea = MAX_ANIMATED_FLOW_LINES_PER_AREA,
+  } = params;
+  const { nodes, nodePointById, areaCategories, stationPositions } = topology;
+
+  // 1. Per-slot link values (reuses parsed directions but re-evaluates slot values)
+  const { links } = extractIntraAreaLinks(lineSeries, clampedNetworkFlowSlotIndex);
+
+  // 2. Per-slot intertie aggregation. We pass fresh Maps/Sets here — the
+  // topology's station/degree maps are already finalized and must not be mutated.
+  const { intertieFacilityMap, intertieBridgeMap } = extractIntertieData(
+    filteredIntertieSeries,
+    clampedNetworkFlowSlotIndex,
+    new Set<string>(),
+    new Map<string, Set<string>>(),
+    new Map<string, number>(),
+  );
+
+  // 3. Build rendered links and intertie line data for this slot
+  const renderedLinks = buildRenderedLinks(links, stationPositions);
   const intertieBridgeLineData = buildIntertieBridgeLines(intertieBridgeMap);
   const intertieFacilityLineData = buildIntertieFacilityLines(intertieFacilityMap, nodePointById);
 
-  // 6. Build animation paths
+  // 4. Build animation paths
   const majorFlowAnimationPaths = buildFlowAnimationPaths(renderedLinks, nodePointById, maxAnimatedFlowLinesPerArea);
   const intertieAnimationPaths = buildIntertieAnimationPaths(intertieFacilityLineData, intertieBridgeLineData);
 
-  // 7. Assemble chart option
-  return {
+  // 5. Assemble chart option
+  const option = {
     animationDurationUpdate: 360,
-    __majorFlowAnimationPaths: majorFlowAnimationPaths,
-    __intertieAnimationPaths: intertieAnimationPaths,
     tooltip: {
       trigger: "item",
       confine: true,
@@ -317,6 +374,8 @@ export function buildFlowNetworkOption(params: NetworkFlowBuilderParams) {
       },
     ],
   };
+
+  return { option, majorFlowAnimationPaths, intertieAnimationPaths };
 }
 
 /**


### PR DESCRIPTION
## Summary

ダッシュボード表示の軽量化 P0 施策。機能は維持したまま、時刻スライダ操作・テーマ切替・エリア選択時の再レンダコストを削減する。

- **セクションの `React.memo` 化**: area-cards / congestion / dashboard-header / generation / generator-status / jepx-market / network / rankings / summary-cards の 9 セクションをメモ化。無関係な state 変化で再レンダが波及しなくなる
- **`dashboard-app.tsx` ハンドラ安定化**: `registerNetworkFlowChart` / `syncNetworkOverlayViewport` / `toggleReorderMode` を `useCallback` 化し、メモ化した子コンポーネントの参照等価性を維持
- **`network-flow-builder.ts` の topology / per-slot 分離**:
  - `buildFlowNetworkTopology()` … nodes / categoryIndex / stationPositions 等のスロット非依存な重い計算をデータ・日付単位でキャッシュ
  - `buildFlowNetworkOption(topology, slotParams)` … リンク値・連系線集計・アニメーションパスのみ再計算
  - `__majorFlowAnimationPaths` の型アサーションハックを廃止し、戻り値として明示的に公開

## Test plan

- [x] `npx tsc --noEmit` PASS
- [x] `npm run lint` PASS（既存 warning のみ、本 PR 起因なし）
- [x] `npm test` 129/129 PASS
- [ ] CI で `npm run build` / Playwright E2E 通過確認
- [ ] マージ後、Pages デプロイで以下を目視確認
  - [ ] 時刻スライダドラッグ時のレスポンス
  - [ ] ダークモード切替で全セクションが正しく追従
  - [ ] ネットワーク図の topology・アニメーションが従来通り
  - [ ] エリアセレクタ切替でのフィルタリング挙動

## Follow-up (P1 以降)

- `chart-options.ts` (1,025 行) の機能別分割と動的 import
- スパークラインの Canvas レンダラ化
- 時刻スライダに `useTransition` を併用

https://claude.ai/code/session_01GrUay79yf7PicgT3TiSLrN