### PR TITLE
perf(generator-status): lazy off-screen rendering and canvas inline charts (P2)

### DIFF
--- a/src/components/sections/generator-status-section.tsx
+++ b/src/components/sections/generator-status-section.tsx
@@ -1,6 +1,5 @@
 import type { GeneratorStatusCard, GeneratorTreemapItem } from "@/lib/dashboard-computations";
-import { SOURCE_COLOR_MAP } from "@/lib/constants";
-import { decimalFmt, formatCompactEnergy, manKwFmt, normalizeSourceName } from "@/lib/formatters";
+import { decimalFmt, formatCompactEnergy, normalizeSourceName } from "@/lib/formatters";
 import {
   buildGeneratorTreemapOption,
   buildAreaGenerationTimeSeriesOption,
@@ -167,6 +166,14 @@ function ExpandedCardModal({
                 <div
                   key={`${card.area}-exp-${unit.label}-${idx}`}
                   className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm transition-colors hover:bg-slate-50 dark:hover:bg-slate-700/40"
+                  // For large unit lists, let the browser skip layout/paint for
+                  // off-screen items. Cheap win vs. JS virtualization and no
+                  // measurable impact for smaller lists.
+                  style={
+                    units.length >= 50
+                      ? { contentVisibility: "auto", containIntrinsicSize: "auto 32px" }
+                      : undefined
+                  }
                 >
                   <span className="w-5 shrink-0 text-right tabular-nums text-xs text-slate-400">
                     {idx + 1}
@@ -394,7 +401,7 @@ function GeneratorStatusSectionImpl({
                       <ReactECharts
                         option={chartOption}
                         style={{ height: isMobileViewport ? 140 : 170 }}
-                        opts={{ renderer: "svg" }}
+                        opts={{ renderer: "canvas" }}
                       />
                     </div>
                     {/* Mini legend for this chart */}


### PR DESCRIPTION
## Summary

発電ユニットセクションまわりの軽微な最適化（P2）。機能は維持。

- **展開モーダルのユニット一覧に `content-visibility: auto`**  
  `units.length >= 50` のときのみ、各グリッドセルに `contentVisibility: "auto"` + `containIntrinsicSize: "auto 32px"` を付与。画面外セルはブラウザがレイアウト・ペイントをスキップ。JS 仮想化なしでネイティブ最適化だけで軽量化し、少量リストには無影響。
- **エリア別インラインチャート（最大9枚）を SVG → Canvas に**  
  同時描画で SVG ノードが増えると再レイアウトコストが嵩むため。展開モーダル内の全画面チャートは画質優先で SVG のまま。
- **pre-existing lint warning 解消**  
  生成ステータスセクションの未使用 import (`SOURCE_COLOR_MAP`, `manKwFmt`) を削除。

**`formatJstDateTime` のキャッシュ**は調査結果として不要と判断:
唯一の呼び出し元 (`use-dashboard-data.ts`) で既に `useMemo` 済み。追加の工夫は速度に影響しないためスキップ。

## Test plan

- [x] `npx tsc --noEmit` PASS
- [x] `npm run lint` PASS（0 warnings）
- [x] `npm test` 129/129 PASS
- [ ] CI で build / Playwright E2E 通過確認
- [ ] マージ後、Pages デプロイで以下を目視確認
  - [ ] ユニット数の多いエリア（例: 中部・関西）の展開モーダルを開いたときの挙動
  - [ ] モーダル内でのスクロール時にレイアウト崩れがないこと
  - [ ] エリア別インラインチャート 9 枚の見た目・ツールチップが従来通り

## Follow-up (P3 候補)

- 実機での React DevTools Profiler 再計測とベースライン更新（手動作業）
- ECharts 6 の `incrementalRender` / `progressive` オプション活用（ヒートマップ系）
- Service Worker でのデータキャッシュ

https://claude.ai/code/session_01GrUay79yf7PicgT3TiSLrN