### PR TITLE
発電方式別トレンドを1時間換算で表示

### DIFF
--- a/src/lib/chart-options/generation.ts
+++ b/src/lib/chart-options/generation.ts
@@ -4,7 +4,6 @@
 
 import { SOURCE_COLORS, SOURCE_COLOR_MAP } from "../constants";
 import {
-  numberFmt,
   decimalFmt,
   normalizeSourceName,
   formatCompactEnergy,
@@ -24,9 +23,11 @@ export function buildGenerationLineOption(
   isDark = false,
 ) {
   const c = chartColors(isDark);
+  // 元データは30分スロット毎のkWh。2倍して1時間換算kWhとして表示する。
+  const HOURLY_SCALE = 2;
   return {
     backgroundColor: "transparent",
-    tooltip: { trigger: "axis", valueFormatter: (value: number) => `${numberFmt.format(value)} MW` },
+    tooltip: { trigger: "axis", valueFormatter: (value: number) => formatCompactEnergy(value) },
     legend: {
       type: "scroll",
       top: 8,
@@ -47,11 +48,11 @@ export function buildGenerationLineOption(
     },
     yAxis: {
       type: "value",
-      name: "発電量(MW)",
+      name: "発電量(1時間換算)",
       nameLocation: "middle",
       nameGap: isMobile ? 36 : 44,
       nameTextStyle: { color: c.axisName, fontSize: isMobile ? 10 : 11 },
-      axisLabel: { color: c.axis, formatter: (v: number) => numberFmt.format(v) },
+      axisLabel: { color: c.axis, formatter: (v: number) => formatCompactEnergy(v) },
     },
     graphic:
       sourceKeys.length > 0
@@ -66,7 +67,7 @@ export function buildGenerationLineOption(
       symbol: "none",
       lineStyle: { width: 2 },
       color: sourceColorByName.get(source) ?? SOURCE_COLOR_MAP[source] ?? SOURCE_COLORS[idx % SOURCE_COLORS.length],
-      data: scopedSeries.map((point) => point.values[source] ?? 0),
+      data: scopedSeries.map((point) => (point.values[source] ?? 0) * HOURLY_SCALE),
     })),
   };
 }


### PR DESCRIPTION
## 概要

`発電方式別 30分推移` グラフの数値が、30分スロットあたりの kWh のまま表示されていてわかりづらかったので、1時間換算（×2）の値で表示するように変更しました。

## 変更点

`src/lib/chart-options/generation.ts` の `buildGenerationLineOption`:

- 系列データを2倍して 1時間換算 kWh（＝そのスロットの平均kWに相当）で表示
- Y軸ラベルを `発電量(MW)` → `発電量(1時間換算)` に変更（実際の値の単位は formatCompactEnergy が自動でスケール表示）
- Y軸目盛り・ツールチップとも `formatCompactEnergy` を使用し、値の大きさに応じて `kWh / MWh / GWh / TWh` を自動で切り替え（元のラベルは `MW` 固定で実値とミスマッチでした）

## 単位の整理

- 元データ（OCCTO CSV）: 30分スロットあたり `kWh`（列名 `HH:MM[kWh]`）
- 変更前の表示: 30分値の生 kWh を `MW` というラベルで表示（不整合）
- 変更後の表示: 30分値 × 2 = 1時間換算 kWh を、`kWh / MWh / GWh` で自動スケール表示

## テスト

- [x] `npx vitest run` — 129/129 passed
- [x] `npx tsc --noEmit` — 変更ファイルに新規エラーなし
- [x] `npx eslint src/lib/chart-options/generation.ts` — 警告なし
- [ ] ブラウザでグラフ表示・ツールチップ・ダーク/ライト切り替えを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_011yVJjjL8HUNWpHm4rC7HVZ)_