### PR TITLE
発電方式別トレンドのカード名に1時間換算MWhを明記

### DIFF
--- a/src/components/sections/generation-section.tsx
+++ b/src/components/sections/generation-section.tsx
@@ -38,7 +38,7 @@ function GenerationSectionImpl({
     <section className="grid grid-cols-1 gap-4 lg:grid-cols-12">
       {showGenerationTrend ? (
         <Panel
-          title="発電方式別 30分推移"
+          title="発電方式別 30分推移（1時間換算MWh）"
           className={showSourceComposition ? "lg:col-span-7" : "lg:col-span-12"}
           testId="generation-trend-panel"
         >
@@ -59,7 +59,7 @@ function GenerationSectionImpl({
               ))}
             </select>
           </div>
-          <div data-testid="generation-trend-chart" role="img" aria-label="発電方式別30分推移チャート">
+          <div data-testid="generation-trend-chart" role="img" aria-label="発電方式別30分推移チャート（1時間換算MWh）">
             <ReactECharts option={generationLineOption} style={{ height: 360 }} />
           </div>
         </Panel>

--- a/tests/dashboard.mobile.spec.ts
+++ b/tests/dashboard.mobile.spec.ts
@@ -22,7 +22,7 @@ test("mobile overview mode suppresses heavy sections @mobile", async ({ page }) 
 
   await expect(page.getByRole("heading", { level: 2, name: "エリア別需給カード" })).toBeVisible();
   await expect(page.getByRole("heading", { level: 2, name: "発電方式 構成比" })).toBeVisible();
-  await expect(page.getByRole("heading", { level: 2, name: "発電方式別 30分推移" })).toHaveCount(0);
+  await expect(page.getByRole("heading", { level: 2, name: "発電方式別 30分推移（1時間換算MWh）" })).toHaveCount(0);
   await expect(page.getByRole("heading", { level: 2, name: "エリアネットワーク潮流（地域内送電線）" })).toBeVisible();
   await expect(page.getByRole("heading", { level: 2, name: "高発電ユニット上位" })).toHaveCount(0);
   await expect(page.getByRole("heading", { level: 2, name: "主要線路の潮流ヒートマップ" })).toHaveCount(0);

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -56,7 +56,7 @@ test("overview mode hides deep-dive sections", async ({ page }) => {
 
   await expect(page.getByRole("heading", { level: 2, name: "エリア別需給カード" })).toBeVisible();
   await expect(page.getByRole("heading", { level: 2, name: "発電方式 構成比" })).toBeVisible();
-  await expect(page.getByRole("heading", { level: 2, name: "発電方式別 30分推移" })).toHaveCount(0);
+  await expect(page.getByRole("heading", { level: 2, name: "発電方式別 30分推移（1時間換算MWh）" })).toHaveCount(0);
   await expect(page.getByRole("heading", { level: 2, name: "エリアネットワーク潮流（地域内送電線）" })).toBeVisible();
   await expect(page.getByRole("heading", { level: 2, name: "高発電ユニット上位" })).toHaveCount(0);
 });


### PR DESCRIPTION
## 概要

#88 で発電方式別トレンドの数値を1時間換算に変更したのに合わせて、カードのタイトルにも `1時間換算MWh` であることを明記しました。

## 変更点

- `src/components/sections/generation-section.tsx`
  - Panel タイトル: `発電方式別 30分推移` → `発電方式別 30分推移（1時間換算MWh）`
  - aria-label: `発電方式別30分推移チャート` → `発電方式別30分推移チャート（1時間換算MWh）`
- `tests/dashboard.spec.ts` / `tests/dashboard.mobile.spec.ts`
  - 上記タイトル変更に追従して、モバイル時の heading 不可視アサーションの文字列を更新

## テスト

- [x] `npx vitest run` — 129/129 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_011yVJjjL8HUNWpHm4rC7HVZ)_