### PR TITLE
fix: keep dashboard charts within resized containers

### DIFF
--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -95,8 +95,7 @@ import { useTimeSlider } from "@/hooks/use-time-slider";
 import { useSectionVisibility } from "@/hooks/use-section-visibility";
 import { useSectionOrder } from "@/hooks/use-section-order";
 import { SwapyContainer } from "@/components/ui/swapy-container";
-
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type DashboardAppProps = {
   initialData: DashboardData;

--- a/src/components/sections/area-cards-section.tsx
+++ b/src/components/sections/area-cards-section.tsx
@@ -13,10 +13,9 @@ import {
   SupplyDemandMeter,
   NetFlowMeter,
 } from "@/components/ui/dashboard-ui";
-import dynamic from "next/dynamic";
 import { memo, useMemo } from "react";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type AreaCardsSectionProps = {
   areaSupplyCards: AreaSupplyCard[];

--- a/src/components/sections/congestion-section.tsx
+++ b/src/components/sections/congestion-section.tsx
@@ -1,10 +1,9 @@
-import dynamic from "next/dynamic";
 import { memo } from "react";
 import type { CongestionSummary } from "@/lib/chart-options/congestion";
 import { CompactStatCard, Panel } from "@/components/ui/dashboard-ui";
 import { numberFmt, decimalFmt } from "@/lib/formatters";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type CongestionSectionProps = {
   congestionData: CongestionSummary;

--- a/src/components/sections/generation-section.tsx
+++ b/src/components/sections/generation-section.tsx
@@ -1,10 +1,9 @@
-import dynamic from "next/dynamic";
 import { memo } from "react";
 import { Panel, CompositionLegendList } from "@/components/ui/dashboard-ui";
 import { ChartErrorBoundary } from "@/components/ui/error-boundary";
 import { SELECT_COMPACT_CLASS } from "@/lib/styles";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type GenerationSectionProps = {
   showGenerationTrend: boolean;

--- a/src/components/sections/generator-status-section.tsx
+++ b/src/components/sections/generator-status-section.tsx
@@ -6,11 +6,10 @@ import {
   buildExpandedAreaGenerationTimeSeriesOption,
   type AreaGenerationSeries,
 } from "@/lib/chart-options/generator-status";
-import dynamic from "next/dynamic";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type GeneratorStatusSectionProps = {
   cards: GeneratorStatusCard[];

--- a/src/components/sections/network-section.tsx
+++ b/src/components/sections/network-section.tsx
@@ -1,4 +1,3 @@
-import dynamic from "next/dynamic";
 import { memo, type MutableRefObject, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { buildExpandedFlowNetworkOption } from "@/lib/network-flow-builder";
@@ -18,7 +17,7 @@ import {
 import { MAX_ANIMATED_FLOW_LINES_PER_AREA } from "@/lib/constants";
 import { Panel } from "@/components/ui/dashboard-ui";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type NetworkSectionProps = {
   flowNetworkOption: Record<string, unknown>;

--- a/src/components/ui/responsive-echarts.tsx
+++ b/src/components/ui/responsive-echarts.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useRef } from "react";
+import type { EChartsType } from "echarts";
+import type { EChartsReactProps } from "echarts-for-react/lib/types";
+
+const ECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+
+/**
+ * Keeps an ECharts instance in sync with its actual layout container.
+ *
+ * echarts-for-react listens for window resize events, but dashboard grids can
+ * finish reflowing after that event. Observing the container itself avoids a
+ * stale canvas/SVG width (and the resulting chart overflow).
+ */
+export function ResponsiveECharts({
+  style,
+  onChartReady,
+  ...props
+}: EChartsReactProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+  const frameRef = useRef<number | null>(null);
+
+  const resizeChart = useCallback(() => {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+    }
+
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      const host = hostRef.current;
+      if (host && host.clientWidth > 0 && host.clientHeight > 0) {
+        chartRef.current?.resize({
+          width: host.clientWidth,
+          height: host.clientHeight,
+        });
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const observer = new ResizeObserver(resizeChart);
+    observer.observe(host);
+    return () => {
+      observer.disconnect();
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    };
+  }, [resizeChart]);
+
+  const handleChartReady = useCallback(
+    (chart: EChartsType) => {
+      chartRef.current = chart;
+      resizeChart();
+      onChartReady?.(chart);
+    },
+    [onChartReady, resizeChart],
+  );
+
+  return (
+    <div ref={hostRef} style={{ ...style, minWidth: 0 }}>
+      <ECharts
+        {...props}
+        autoResize={false}
+        onChartReady={handleChartReady}
+        style={{ width: "100%", height: "100%" }}
+      />
+    </div>
+  );
+}

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -83,6 +83,25 @@ test("time slider updates the network timestamp and keeps charts rendered", asyn
   await waitForChartSurface(page.getByTestId("inter-area-flow-chart"));
 });
 
+test("charts follow their containers when the viewport is resized", async ({ page }) => {
+  await waitForDashboardReady(page);
+  const chart = page.getByTestId("generation-trend-chart");
+
+  await page.setViewportSize({ width: 900, height: 900 });
+  await expect.poll(() => chart.evaluate((node) => {
+    const surface = node.querySelector("canvas, svg");
+    if (!surface) return Number.POSITIVE_INFINITY;
+    return Math.abs(surface.getBoundingClientRect().width - node.getBoundingClientRect().width);
+  })).toBeLessThanOrEqual(1);
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await expect.poll(() => chart.evaluate((node) => {
+    const surface = node.querySelector("canvas, svg");
+    if (!surface) return Number.POSITIVE_INFINITY;
+    return Math.abs(surface.getBoundingClientRect().width - node.getBoundingClientRect().width);
+  })).toBeLessThanOrEqual(1);
+});
+
 test("network flow chart keeps visible motion on major lines", async ({ page }) => {
   await waitForDashboardReady(page);
 


### PR DESCRIPTION
### Motivation

- Charts rendered by `echarts-for-react` sometimes kept a stale canvas/SVG size after layout reflows (e.g. when the browser window or dashboard grid changed width), causing chart lines to overflow their panels. The goal is to ensure chart surfaces always match their container after reflow.

### Description

- Add a shared responsive wrapper `ResponsiveECharts` (`src/components/ui/responsive-echarts.tsx`) that observes the chart container with `ResizeObserver`, batches updates with `requestAnimationFrame`, disables `ECharts` auto-resize, and explicitly calls the instance `resize` when needed. 
- Migrate dashboard charts to use the wrapper by replacing dynamic `echarts-for-react` imports with `ResponsiveECharts` in the dashboard components (`src/components/dashboard-app.tsx`, `src/components/sections/{generation,congestion,area-cards,generator-status,network}-section.tsx`).
- Add a Playwright regression test (`tests/dashboard.spec.ts`) asserting that a chart's canvas/SVG width matches its container after shrinking and expanding the viewport.

### Testing

- `npm test` (Vitest) — all tests passed (`129 tests` succeeded). 
- `npm run lint` (ESLint) — completed successfully. 
- `npx tsc --noEmit` (TypeScript) — type check passed with no errors. 
- `git diff --check` — no whitespace or diff-check issues detected. 
- `npm run build` — failed in this environment due to inability to fetch Google Fonts during the Next.js/Turbopack build (external network resource blocked), unrelated to the chart code changes. 
- Playwright browser test (`npx playwright test` for the new resize assertion) — blocked: the Chromium browser binary was not available and `npx playwright install chromium` failed due to an HTTP 403 from the browser CDN, so the browser-run UI test could not be fully executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ad8d917908321a2c63f49ad934dcf)