### PR TITLE
Make ECharts responsive to container size and add shared Y-axis for generator charts

### DIFF
--- a/src/components/dashboard-app.tsx
+++ b/src/components/dashboard-app.tsx
@@ -95,8 +95,7 @@ import { useTimeSlider } from "@/hooks/use-time-slider";
 import { useSectionVisibility } from "@/hooks/use-section-visibility";
 import { useSectionOrder } from "@/hooks/use-section-order";
 import { SwapyContainer } from "@/components/ui/swapy-container";
-
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type DashboardAppProps = {
   initialData: DashboardData;

--- a/src/components/sections/area-cards-section.tsx
+++ b/src/components/sections/area-cards-section.tsx
@@ -13,10 +13,9 @@ import {
   SupplyDemandMeter,
   NetFlowMeter,
 } from "@/components/ui/dashboard-ui";
-import dynamic from "next/dynamic";
 import { memo, useMemo } from "react";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type AreaCardsSectionProps = {
   areaSupplyCards: AreaSupplyCard[];

--- a/src/components/sections/congestion-section.tsx
+++ b/src/components/sections/congestion-section.tsx
@@ -1,10 +1,9 @@
-import dynamic from "next/dynamic";
 import { memo } from "react";
 import type { CongestionSummary } from "@/lib/chart-options/congestion";
 import { CompactStatCard, Panel } from "@/components/ui/dashboard-ui";
 import { numberFmt, decimalFmt } from "@/lib/formatters";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type CongestionSectionProps = {
   congestionData: CongestionSummary;

--- a/src/components/sections/generation-section.tsx
+++ b/src/components/sections/generation-section.tsx
@@ -1,10 +1,9 @@
-import dynamic from "next/dynamic";
 import { memo } from "react";
 import { Panel, CompositionLegendList } from "@/components/ui/dashboard-ui";
 import { ChartErrorBoundary } from "@/components/ui/error-boundary";
 import { SELECT_COMPACT_CLASS } from "@/lib/styles";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type GenerationSectionProps = {
   showGenerationTrend: boolean;

--- a/src/components/sections/generator-status-section.tsx
+++ b/src/components/sections/generator-status-section.tsx
@@ -4,13 +4,13 @@ import {
   buildGeneratorTreemapOption,
   buildAreaGenerationTimeSeriesOption,
   buildExpandedAreaGenerationTimeSeriesOption,
+  calculateGenerationYAxisMax,
   type AreaGenerationSeries,
 } from "@/lib/chart-options/generator-status";
-import dynamic from "next/dynamic";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type GeneratorStatusSectionProps = {
   cards: GeneratorStatusCard[];
@@ -43,11 +43,13 @@ function ExpandedCardModal({
   slotLabels,
   onClose,
   isDark = false,
+  yAxisMax,
 }: {
   card: GeneratorStatusCard;
   slotLabels: string[];
   onClose: () => void;
   isDark?: boolean;
+  yAxisMax?: number;
 }) {
   // Close on Escape key
   useEffect(() => {
@@ -73,8 +75,9 @@ function ExpandedCardModal({
         slotLabels,
         card.areaColor,
         isDark,
+        yAxisMax,
       ),
-    [card, slotLabels, isDark],
+    [card, slotLabels, isDark, yAxisMax],
   );
 
   const units =
@@ -273,6 +276,13 @@ function GeneratorStatusSectionImpl({
     [treemapItems, isMobileViewport, isDark],
   );
 
+  const sharedYAxisMax = useMemo(
+    () => calculateGenerationYAxisMax(
+      cards.map((card) => card.timeSeries as AreaGenerationSeries[]),
+    ),
+    [cards],
+  );
+
   const areaChartOptions = useMemo(
     () =>
       cards.map((card) => ({
@@ -283,9 +293,10 @@ function GeneratorStatusSectionImpl({
           card.areaColor,
           isMobileViewport,
           isDark,
+          sharedYAxisMax,
         ),
       })),
-    [cards, slotLabels, isMobileViewport, isDark],
+    [cards, slotLabels, isMobileViewport, isDark, sharedYAxisMax],
   );
   const areaChartMap = useMemo(
     () => new Map(areaChartOptions.map((item) => [item.area, item.option])),
@@ -461,6 +472,7 @@ function GeneratorStatusSectionImpl({
           slotLabels={slotLabels}
           onClose={handleClose}
           isDark={isDark}
+          yAxisMax={sharedYAxisMax}
         />,
         document.body,
       )}

--- a/src/components/sections/network-section.tsx
+++ b/src/components/sections/network-section.tsx
@@ -1,4 +1,3 @@
-import dynamic from "next/dynamic";
 import { memo, type MutableRefObject, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { buildExpandedFlowNetworkOption } from "@/lib/network-flow-builder";
@@ -18,7 +17,7 @@ import {
 import { MAX_ANIMATED_FLOW_LINES_PER_AREA } from "@/lib/constants";
 import { Panel } from "@/components/ui/dashboard-ui";
 
-const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+import { ResponsiveECharts as ReactECharts } from "@/components/ui/responsive-echarts";
 
 type NetworkSectionProps = {
   flowNetworkOption: Record<string, unknown>;

--- a/src/components/ui/responsive-echarts.tsx
+++ b/src/components/ui/responsive-echarts.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useRef } from "react";
+import type { EChartsType } from "echarts";
+import type { EChartsReactProps } from "echarts-for-react/lib/types";
+
+const ECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+
+/**
+ * Keeps an ECharts instance in sync with its actual layout container.
+ *
+ * echarts-for-react listens for window resize events, but dashboard grids can
+ * finish reflowing after that event. Observing the container itself avoids a
+ * stale canvas/SVG width (and the resulting chart overflow).
+ */
+export function ResponsiveECharts({
+  style,
+  onChartReady,
+  ...props
+}: EChartsReactProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+  const frameRef = useRef<number | null>(null);
+
+  const resizeChart = useCallback(() => {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+    }
+
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      const host = hostRef.current;
+      if (host && host.clientWidth > 0 && host.clientHeight > 0) {
+        chartRef.current?.resize({
+          width: host.clientWidth,
+          height: host.clientHeight,
+        });
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const observer = new ResizeObserver(resizeChart);
+    observer.observe(host);
+    return () => {
+      observer.disconnect();
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    };
+  }, [resizeChart]);
+
+  const handleChartReady = useCallback(
+    (chart: EChartsType) => {
+      chartRef.current = chart;
+      resizeChart();
+      onChartReady?.(chart);
+    },
+    [onChartReady, resizeChart],
+  );
+
+  return (
+    <div ref={hostRef} style={{ ...style, minWidth: 0 }}>
+      <ECharts
+        {...props}
+        autoResize={false}
+        onChartReady={handleChartReady}
+        style={{ width: "100%", height: "100%" }}
+      />
+    </div>
+  );
+}

--- a/src/lib/chart-options/generator-status.test.ts
+++ b/src/lib/chart-options/generator-status.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildAreaGenerationTimeSeriesOption,
+  calculateGenerationYAxisMax,
+  type AreaGenerationSeries,
+} from "./generator-status";
+
+const series = (data: number[]): AreaGenerationSeries => ({
+  name: "発電所",
+  color: "#0f766e",
+  data,
+});
+
+describe("generator status chart axes", () => {
+  test("calculates a rounded common maximum across all areas", () => {
+    expect(calculateGenerationYAxisMax([
+      [series([100, 450])],
+      [series([2_100, 3_800])],
+      [series([900, 1_200])],
+    ])).toBe(5_000);
+  });
+
+  test("applies the supplied common range to an area chart", () => {
+    const option = buildAreaGenerationTimeSeriesOption(
+      [series([100, 450])],
+      ["00:00", "00:30"],
+      "#0f766e",
+      false,
+      false,
+      5_000,
+    ) as { yAxis: { min: number; max: number } };
+
+    expect(option.yAxis).toMatchObject({ min: 0, max: 5_000 });
+  });
+
+  test("leaves the upper bound automatic when all data is empty or zero", () => {
+    expect(calculateGenerationYAxisMax([[], [series([0, 0])]])).toBeUndefined();
+  });
+});

--- a/src/lib/chart-options/generator-status.ts
+++ b/src/lib/chart-options/generator-status.ts
@@ -125,12 +125,37 @@ export type AreaGenerationSeries = {
   data: number[];
 };
 
+/** Returns a rounded common upper bound so per-area charts are comparable. */
+export function calculateGenerationYAxisMax(
+  seriesGroups: AreaGenerationSeries[][],
+): number | undefined {
+  const maximum = seriesGroups.reduce(
+    (groupMax, seriesList) => seriesList.reduce(
+      (seriesMax, series) => series.data.reduce(
+        (dataMax, value) => Number.isFinite(value) ? Math.max(dataMax, value) : dataMax,
+        seriesMax,
+      ),
+      groupMax,
+    ),
+    0,
+  );
+
+  if (maximum <= 0) return undefined;
+
+  const paddedMaximum = maximum * 1.05;
+  const magnitude = 10 ** Math.floor(Math.log10(paddedMaximum));
+  const normalized = paddedMaximum / magnitude;
+  const niceNormalized = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return niceNormalized * magnitude;
+}
+
 export function buildAreaGenerationTimeSeriesOption(
   seriesList: AreaGenerationSeries[],
   slotLabels: string[],
   areaColor: string,
   isMobile: boolean,
   isDark = false,
+  yAxisMax?: number,
 ): Record<string, unknown> {
   if (seriesList.length === 0 || slotLabels.length === 0) {
     return { graphic: emptyGraphic("データなし", isDark) };
@@ -164,6 +189,8 @@ export function buildAreaGenerationTimeSeriesOption(
     },
     yAxis: {
       type: "value",
+      min: 0,
+      max: yAxisMax,
       show: true,
       axisLine: { show: false },
       axisTick: { show: false },
@@ -215,6 +242,7 @@ export function buildExpandedAreaGenerationTimeSeriesOption(
   slotLabels: string[],
   areaColor: string,
   isDark = false,
+  yAxisMax?: number,
 ): Record<string, unknown> {
   if (seriesList.length === 0 || slotLabels.length === 0) {
     return { graphic: emptyGraphic("データなし", isDark) };
@@ -279,6 +307,8 @@ export function buildExpandedAreaGenerationTimeSeriesOption(
     },
     yAxis: {
       type: "value",
+      min: 0,
+      max: yAxisMax,
       show: true,
       axisLine: { show: false },
       axisTick: { show: false },

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -83,6 +83,25 @@ test("time slider updates the network timestamp and keeps charts rendered", asyn
   await waitForChartSurface(page.getByTestId("inter-area-flow-chart"));
 });
 
+test("charts follow their containers when the viewport is resized", async ({ page }) => {
+  await waitForDashboardReady(page);
+  const chart = page.getByTestId("generation-trend-chart");
+
+  await page.setViewportSize({ width: 900, height: 900 });
+  await expect.poll(() => chart.evaluate((node) => {
+    const surface = node.querySelector("canvas, svg");
+    if (!surface) return Number.POSITIVE_INFINITY;
+    return Math.abs(surface.getBoundingClientRect().width - node.getBoundingClientRect().width);
+  })).toBeLessThanOrEqual(1);
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await expect.poll(() => chart.evaluate((node) => {
+    const surface = node.querySelector("canvas, svg");
+    if (!surface) return Number.POSITIVE_INFINITY;
+    return Math.abs(surface.getBoundingClientRect().width - node.getBoundingClientRect().width);
+  })).toBeLessThanOrEqual(1);
+});
+
 test("network flow chart keeps visible motion on major lines", async ({ page }) => {
   await waitForDashboardReady(page);
 


### PR DESCRIPTION
### Motivation

- Prevent chart canvases/SVGs from becoming stale when grid layouts reflow after window resize by observing the chart container instead of relying on `window` resize events. 
- Make per-area generator time-series charts comparable by computing and applying a rounded shared upper Y bound. 
- Improve test reliability for visual/layout behavior by explicitly ensuring charts resize to their host containers.

### Description

- Add a `ResponsiveECharts` wrapper component at `src/components/ui/responsive-echarts.tsx` that uses `ResizeObserver` and `requestAnimationFrame` to keep an `echarts-for-react` instance sized to its container. 
- Replace ad-hoc dynamic imports of `echarts-for-react` with the new `ResponsiveECharts` in multiple sections (`dashboard-app`, `area-cards-section`, `congestion-section`, `generation-section`, `generator-status-section`, and `network-section`).
- Introduce `calculateGenerationYAxisMax` in `src/lib/chart-options/generator-status.ts` and thread a `sharedYAxisMax` through `GeneratorStatusSection` into both the compact and expanded chart builders via a new optional `yAxisMax` parameter. 
- Add a unit test for axis calculation at `src/lib/chart-options/generator-status.test.ts` and a Playwright test update `tests/dashboard.spec.ts` that asserts charts follow their containers when the viewport is resized.

### Testing

- Ran the unit tests with `vitest` including `generator-status.test.ts`, and the generator Y-axis calculation and chart option assertions passed. 
- Ran the Playwright dashboard tests including the new `charts follow their containers when the viewport is resized` scenario, and the end-to-end checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ad8d917908321a2c63f49ad934dcf)